### PR TITLE
Fixes Predicate::serializeField() to serialize values correctly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- Incorrect serialisation of Predicate values, a hangover from the official api client, means that simple operations such as providing a quoted string in a fulltext search, i.e. `Predicate::fulltext('document', 'A "Quoted" string')` would yield 400 errors from the API. This is now fixed and new tests added prove it.
 
 ## 0.3.5 - 2020-06-16
 

--- a/src/Predicate.php
+++ b/src/Predicate.php
@@ -7,11 +7,9 @@ use DateTimeInterface;
 use Prismic\Exception\InvalidArgument;
 use Stringable;
 
-use function implode;
+use function array_values;
 use function is_array;
-use function is_bool;
 use function is_numeric;
-use function is_string;
 
 final class Predicate implements Stringable
 {
@@ -72,24 +70,11 @@ final class Predicate implements Stringable
      */
     private function serializeField($value) : string
     {
-        if (is_string($value)) {
-            return '"' . $value . '"';
-        }
-
-        if (is_bool($value)) {
-            return $value ? 'true' : 'false';
-        }
-
         if (is_array($value)) {
-            $fields = [];
-            foreach ($value as $elt) {
-                $fields[] = $this->serializeField($elt);
-            }
-
-            return '[' . implode(', ', $fields) . ']';
+            $value = array_values($value);
         }
 
-        return (string) $value;
+        return Json::encode($value);
     }
 
     /**

--- a/test/Smoke/PredicateUseCaseTest.php
+++ b/test/Smoke/PredicateUseCaseTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace PrismicSmokeTest;
+
+use Prismic\Exception\RequestFailure;
+use Prismic\Predicate;
+
+use function chr;
+use function sprintf;
+
+class PredicateUseCaseTest extends TestCase
+{
+    /** @return string[][] */
+    public function searchTermProvider() : iterable
+    {
+        return [
+            'Double Quoted'      => ['"Quoted String"'],
+            'Normal Terms'       => ['multiple regular terms'],
+            'Angle Brackets'     => ['<something unusual>'],
+            'Emoji'              => ['Search Term with Unicode 🤣'],
+            'Single Quoted'      => ["'Single Quoted Terms'"],
+            'Contains Tab'       => ["Stray\tTab"],
+            'Contains Newline'   => ["New\nLine"],
+            'Contains Backslash' => ['Back \ Slash'],
+            'Contains Form Feed' => ["Form\fFeed"],
+            'Contains CR'        => ["Carriage\rReturn"],
+            'Contains Backspace' => ['Back' . chr(8) . 'Space'],
+        ];
+    }
+
+    /** @dataProvider searchTermProvider */
+    public function testThatFullTextSearchIsPossibleWithAVarietyOfTerms(string $term) : void
+    {
+        foreach ($this->apiInstances() as $host => $api) {
+            $query = $api->createQuery()
+                ->query(Predicate::fulltext('document', $term))
+                ->resultsPerPage(1);
+            try {
+                $api->query($query);
+                $this->addToAssertionCount(1);
+            } catch (RequestFailure $error) {
+                $this->fail(sprintf(
+                    'The full text search for "%s" failed with the error message: %s',
+                    $term,
+                    $error->getMessage()
+                ));
+            }
+        }
+    }
+}

--- a/test/Unit/Document/Fragment/WebLinkTest.php
+++ b/test/Unit/Document/Fragment/WebLinkTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace PrismicTest\Document\Fragment;
+
+use Prismic\Document\Fragment\WebLink;
+use PrismicTest\Framework\TestCase;
+
+class WebLinkTest extends TestCase
+{
+    public function testAccessors() : void
+    {
+        $link = WebLink::new('somewhere', 'target');
+        $this->assertSame('somewhere', $link->url());
+        $this->assertSame('target', $link->target());
+    }
+
+    public function testThatCastingToStringYieldsTheUrl() : void
+    {
+        $link = WebLink::new('somewhere', 'target');
+        $this->assertSame('somewhere', (string) $link);
+    }
+
+    public function testThatWebLinksAreNotConsideredEmpty() : void
+    {
+        $link = WebLink::new('somewhere', 'target');
+        $this->assertFalse($link->isEmpty());
+    }
+}

--- a/test/Unit/PredicateTest.php
+++ b/test/Unit/PredicateTest.php
@@ -21,7 +21,8 @@ class PredicateTest extends TestCase
         return [
             ['document.type', 'blog-post', '[:d = at(document.type, "blog-post")]'],
             ['my.doc-type.frag-name', 'foo', '[:d = at(my.doc-type.frag-name, "foo")]'],
-            ['document.tags', ['one', 'two', 'three'], '[:d = at(document.tags, ["one", "two", "three"])]'],
+            ['document.tags', ['one', 'two', 'three'], '[:d = at(document.tags, ["one","two","three"])]'],
+            ['my.mytype.boolean', true, '[:d = at(my.mytype.boolean, true)]'],
         ];
     }
 
@@ -43,7 +44,8 @@ class PredicateTest extends TestCase
             ['document.type', 'blog-post', '[:d = not(document.type, "blog-post")]'],
             ['my.doc-type.frag-name', 'foo', '[:d = not(my.doc-type.frag-name, "foo")]'],
             ['my.doc-type.price', 100, '[:d = not(my.doc-type.price, 100)]'],
-            ['document.tags', ['one', 'two', 'three'], '[:d = not(document.tags, ["one", "two", "three"])]'],
+            ['document.tags', ['one', 'two', 'three'], '[:d = not(document.tags, ["one","two","three"])]'],
+            ['my.doc.boolean', true, '[:d = not(my.doc.boolean, true)]'],
         ];
     }
 
@@ -62,8 +64,8 @@ class PredicateTest extends TestCase
     public function anyProvider() : array
     {
         return [
-            ['document.id', ['id1', 'id2'], '[:d = any(document.id, ["id1", "id2"])]'],
-            ['document.tags', ['one', 'two', 'three'], '[:d = any(document.tags, ["one", "two", "three"])]'],
+            ['document.id', ['id1', 'id2'], '[:d = any(document.id, ["id1","id2"])]'],
+            ['document.tags', ['one', 'two', 'three'], '[:d = any(document.tags, ["one","two","three"])]'],
             ['document.tags', ['one'], '[:d = any(document.tags, ["one"])]'],
         ];
     }
@@ -83,8 +85,8 @@ class PredicateTest extends TestCase
     public function inProvider() : array
     {
         return [
-            ['document.id', ['id1', 'id2'], '[:d = in(document.id, ["id1", "id2"])]'],
-            ['my.page.uid', ['uid1', 'uid2'], '[:d = in(my.page.uid, ["uid1", "uid2"])]'],
+            ['document.id', ['id1', 'id2'], '[:d = in(document.id, ["id1","id2"])]'],
+            ['my.page.uid', ['uid1', 'uid2'], '[:d = in(my.page.uid, ["uid1","uid2"])]'],
         ];
     }
 


### PR DESCRIPTION
`Predicate::serializeField()`, [copied from the official php client](https://github.com/prismicio/php-kit/blob/5.1.1/src/Prismic/SimplePredicate.php#L53) incorrectly sanitises values.

The API refuses anything that would be invalid JSON and properly serializing predicate arguments to valid json delegates the reponsibility of making sure input is acceptable to the api client instead of its consumers.

The Unit test for predicate was updated only to account for spaces between serialised array values.