### PR TITLE
Caching in the API Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.4.0 - TBD
+
+### Added
+
+- BC Break: `Prismic\ResultSet\ResultSetFactory` declares a new method `withJsonObject` that is now used to construct Result Sets internally. This is due to implementing caching in the library - keeping BC would have required the provision of a Response factory, or, including a response implementation in order to rehydrate http responses from the cache - this would have added bloat and additional dependencies.
+
+### Changed
+
+- The constructor `Api::get()` now accepts a `Psr\Cache\CacheItemPool` as the final argument so that the client can cache response bodies internally. It's not how I wanted things to go, but experience with trying to cache with the HTTP client alone have proven less than ideal in a number of scenarios with several approaches.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 0.3.7 - 2020-06-18
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "ext-json": "*",
         "laminas/laminas-escaper": "^2.6",
         "php-http/discovery": "^1.8",
+        "psr/cache": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
@@ -45,7 +46,6 @@
         "php-http/curl-client": "^2.1",
         "php-http/mock-client": "^1.3",
         "phpunit/phpunit": "^9.1",
-        "psr/cache": "^1.0",
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/cache": "^5.1"

--- a/samples/CustomHydratingResultSet/MyResultSetFactory.php
+++ b/samples/CustomHydratingResultSet/MyResultSetFactory.php
@@ -32,6 +32,11 @@ class MyResultSetFactory implements ResultSetFactory
         /** Decode the response body */
         $data = Json::decodeObject((string) $response->getBody());
 
+        return $this->withJsonObject($data);
+    }
+
+    public function withJsonObject(object $data) : ResultSet
+    {
         /** Iterate over the results and construct the appropriate document type */
         $results = [];
         foreach ($data->results as $documentData) {

--- a/src/ResultSet/ResultSetFactory.php
+++ b/src/ResultSet/ResultSetFactory.php
@@ -9,4 +9,6 @@ use Psr\Http\Message\ResponseInterface;
 interface ResultSetFactory
 {
     public function withHttpResponse(ResponseInterface $response) : ResultSet;
+
+    public function withJsonObject(object $object) : ResultSet;
 }

--- a/src/ResultSet/StandardResultSetFactory.php
+++ b/src/ResultSet/StandardResultSetFactory.php
@@ -12,4 +12,9 @@ final class StandardResultSetFactory implements ResultSetFactory
     {
         return StandardResultSet::withHttpResponse($response);
     }
+
+    public function withJsonObject(object $object) : ResultSet
+    {
+        return StandardResultSet::factory($object);
+    }
 }

--- a/test/Smoke/CacheTest.php
+++ b/test/Smoke/CacheTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace PrismicSmokeTest;
+
+use Prismic\Api;
+use Prismic\ApiClient;
+use Prismic\Predicate;
+
+use function sha1;
+use function sprintf;
+use function uniqid;
+
+class CacheTest extends TestCase
+{
+    /** @return Api[][] */
+    public function cachingApiClientProvider() : iterable
+    {
+        foreach ($this->compileEndPoints() as $uri => $token) {
+            $api = Api::get($uri, $token, null, null, null, null, $this->psrCachePool());
+
+            yield $api->host() => [$api];
+        }
+    }
+
+    /** @dataProvider cachingApiClientProvider */
+    public function testThatRepeatedQueriesHitTheCache(ApiClient $api) : void
+    {
+        $cache = $this->psrCachePool();
+
+        $query = $api->createQuery()
+            ->resultsPerPage(1)
+            ->query(Predicate::fulltext('document', uniqid('', false)));
+
+        $expectedKey = sha1(sprintf('GET %s', $query->toUrl()));
+
+        $item = $cache->getItem($expectedKey);
+        self::assertFalse($item->isHit());
+
+        $result = $api->query($query);
+
+        $item = $cache->getItem($expectedKey);
+        self::assertTrue($item->isHit());
+
+        self::assertEquals($result, $api->query($query));
+    }
+}

--- a/test/Unit/ApiTest.php
+++ b/test/Unit/ApiTest.php
@@ -19,7 +19,10 @@ use Prismic\Exception\InvalidPreviewToken;
 use Prismic\Exception\PrismicError;
 use Prismic\Exception\RequestFailure;
 use Prismic\Json;
+use PrismicTest\Framework\CacheKeyInvalid;
 use PrismicTest\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException as InvalidCacheKeyError;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -407,6 +410,23 @@ class ApiTest extends TestCase
             return;
         } finally {
             Psr17FactoryDiscovery::setStrategies($strategies);
+        }
+    }
+
+    public function testThatExceptionsThrownDueToInvalidCacheKeysAreWrapped() : void
+    {
+        $cacheException = new CacheKeyInvalid();
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache->method('getItem')
+            ->willThrowException($cacheException);
+
+        $api = Api::get('http://example.com', null, $this->httpClient, null, null, null, $cache);
+
+        try {
+            $api->data();
+            static::fail('An exception was not thrown');
+        } catch (PrismicError $error) {
+            static::assertSame($cacheException, $error->getPrevious());
         }
     }
 }

--- a/test/Unit/ApiTest.php
+++ b/test/Unit/ApiTest.php
@@ -22,7 +22,6 @@ use Prismic\Json;
 use PrismicTest\Framework\CacheKeyInvalid;
 use PrismicTest\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
-use Psr\Cache\InvalidArgumentException as InvalidCacheKeyError;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;

--- a/test/Unit/Framework/CacheKeyInvalid.php
+++ b/test/Unit/Framework/CacheKeyInvalid.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace PrismicTest\Framework;
+
+use Exception;
+use Psr\Cache\InvalidArgumentException;
+
+class CacheKeyInvalid extends Exception implements InvalidArgumentException
+{
+}


### PR DESCRIPTION
Implement caching in the api client to overcome issues decorating HTTP adapters with caching clients.

Decorating [php-http](https://docs.php-http.org/en/latest/plugins/cache.html) with the caching plugin is problematic because the cache keys are not stable. There are ways around that, but it's too complex to document, i.e. custom key generators etc, but it all starts getting implementation specific.

Implementing a shipped HTTP Client decorator with a PSR Cache is reinventing the wheel and would require a whole load of extra deps.
