### PR TITLE
Add Stringable Interface to a number of Types

### DIFF
--- a/src/Document/Fragment/BaseCollection.php
+++ b/src/Document/Fragment/BaseCollection.php
@@ -9,16 +9,20 @@ use Closure;
 use Prismic\Document\Fragment;
 use Prismic\Document\FragmentCollection;
 
+use Stringable;
+
 use function array_filter;
 use function array_keys;
 use function array_values;
 use function count;
 use function end;
+use function implode;
 use function reset;
 
 use const ARRAY_FILTER_USE_BOTH;
+use const PHP_EOL;
 
-abstract class BaseCollection implements FragmentCollection
+abstract class BaseCollection implements FragmentCollection, Stringable
 {
     /** @var Fragment[] */
     protected $fragments;
@@ -135,5 +139,20 @@ abstract class BaseCollection implements FragmentCollection
         return $this->filter(static function (Fragment $fragment): bool {
             return ! $fragment->isEmpty();
         });
+    }
+
+    public function __toString(): string
+    {
+        $buffer = [];
+
+        foreach ($this as $fragment) {
+            if (! $fragment instanceof Stringable) {
+                continue;
+            }
+
+            $buffer[] = (string) $fragment;
+        }
+
+        return implode(PHP_EOL, $buffer);
     }
 }

--- a/src/Document/Fragment/BaseCollection.php
+++ b/src/Document/Fragment/BaseCollection.php
@@ -8,7 +8,6 @@ use ArrayIterator;
 use Closure;
 use Prismic\Document\Fragment;
 use Prismic\Document\FragmentCollection;
-
 use Stringable;
 
 use function array_filter;

--- a/src/Document/Fragment/EmptyFragment.php
+++ b/src/Document/Fragment/EmptyFragment.php
@@ -5,11 +5,17 @@ declare(strict_types=1);
 namespace Prismic\Document\Fragment;
 
 use Prismic\Document\Fragment;
+use Stringable;
 
-final class EmptyFragment implements Fragment
+final class EmptyFragment implements Fragment, Stringable
 {
     public function isEmpty(): bool
     {
         return true;
+    }
+
+    public function __toString(): string
+    {
+        return '';
     }
 }

--- a/src/Document/Fragment/GeoPoint.php
+++ b/src/Document/Fragment/GeoPoint.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Prismic\Document\Fragment;
 
 use Prismic\Document\Fragment;
+use Stringable;
 
-final class GeoPoint implements Fragment
+use function sprintf;
+
+final class GeoPoint implements Fragment, Stringable
 {
     /** @var float */
     private $latitude;
@@ -38,5 +41,10 @@ final class GeoPoint implements Fragment
     public function isEmpty(): bool
     {
         return false;
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('%0.6f,%0.6f', $this->latitude, $this->longitude);
     }
 }

--- a/src/Document/Fragment/Slice.php
+++ b/src/Document/Fragment/Slice.php
@@ -6,8 +6,14 @@ namespace Prismic\Document\Fragment;
 
 use Prismic\Document\Fragment;
 use Prismic\Document\FragmentCollection;
+use Stringable;
 
-final class Slice implements Fragment
+use function array_filter;
+use function implode;
+
+use const PHP_EOL;
+
+final class Slice implements Fragment, Stringable
 {
     /** @var string */
     private $type;
@@ -62,5 +68,15 @@ final class Slice implements Fragment
     public function isEmpty(): bool
     {
         return $this->primary->isEmpty() && $this->items->isEmpty();
+    }
+
+    public function __toString(): string
+    {
+        $buffer = array_filter([
+            $this->primary->isEmpty() ? null : (string) $this->primary,
+            $this->items->isEmpty() ? null : (string) $this->items,
+        ]);
+
+        return implode(PHP_EOL, $buffer);
     }
 }

--- a/src/Document/Fragment/TextElement.php
+++ b/src/Document/Fragment/TextElement.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Prismic\Document\Fragment;
 
 use Prismic\Document\Fragment;
-
 use Stringable;
 
 use function in_array;

--- a/src/Document/Fragment/TextElement.php
+++ b/src/Document/Fragment/TextElement.php
@@ -6,9 +6,11 @@ namespace Prismic\Document\Fragment;
 
 use Prismic\Document\Fragment;
 
+use Stringable;
+
 use function in_array;
 
-final class TextElement implements Fragment
+final class TextElement implements Fragment, Stringable
 {
     public const TYPE_ORDERED_LIST_ITEM = 'o-list-item';
     public const TYPE_UNORDERED_LIST_ITEM = 'list-item';
@@ -126,5 +128,10 @@ final class TextElement implements Fragment
     private function addSpan(Span $span): void
     {
         $this->spans[] = $span;
+    }
+
+    public function __toString(): string
+    {
+        return $this->text;
     }
 }

--- a/src/Value/Language.php
+++ b/src/Value/Language.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Prismic\Value;
 
+use Stringable;
+
 use function assert;
 use function is_string;
 
-final class Language
+final class Language implements Stringable
 {
     /** @var string */
     private $id;
@@ -44,5 +46,10 @@ final class Language
     public function name(): string
     {
         return $this->name;
+    }
+
+    public function __toString() : string
+    {
+        return $this->id;
     }
 }

--- a/src/Value/Language.php
+++ b/src/Value/Language.php
@@ -48,7 +48,7 @@ final class Language implements Stringable
         return $this->name;
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->id;
     }

--- a/src/Value/Type.php
+++ b/src/Value/Type.php
@@ -43,7 +43,7 @@ final class Type implements JsonSerializable, Stringable
         ];
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->id;
     }

--- a/src/Value/Type.php
+++ b/src/Value/Type.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Prismic\Value;
 
 use JsonSerializable;
+use Stringable;
 
-final class Type implements JsonSerializable
+final class Type implements JsonSerializable, Stringable
 {
     /** @var string */
     private $id;
@@ -40,5 +41,10 @@ final class Type implements JsonSerializable
         return [
             $this->id => $this->name,
         ];
+    }
+
+    public function __toString() : string
+    {
+        return $this->id;
     }
 }

--- a/test/Unit/Document/Fragment/EmptyFragmentTest.php
+++ b/test/Unit/Document/Fragment/EmptyFragmentTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace PrismicTest\Document\Fragment;
 
-use Prismic\Document\Fragment\EmptyFragment;
 use PHPUnit\Framework\TestCase;
+use Prismic\Document\Fragment\EmptyFragment;
 
 class EmptyFragmentTest extends TestCase
 {

--- a/test/Unit/Document/Fragment/EmptyFragmentTest.php
+++ b/test/Unit/Document/Fragment/EmptyFragmentTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrismicTest\Document\Fragment;
+
+use Prismic\Document\Fragment\EmptyFragment;
+use PHPUnit\Framework\TestCase;
+
+class EmptyFragmentTest extends TestCase
+{
+    /** @test */
+    public function anEmptyFragmentIsAlwaysConsideredEmpty(): void
+    {
+        $fragment = new EmptyFragment();
+        self::assertTrue($fragment->isEmpty());
+    }
+
+    /** @test */
+    public function anEmptyFragmentIsAnEmptyStringWhenCast(): void
+    {
+        $fragment = new EmptyFragment();
+        self::assertEquals('', (string) $fragment);
+    }
+}

--- a/test/Unit/Document/Fragment/GeoPointTest.php
+++ b/test/Unit/Document/Fragment/GeoPointTest.php
@@ -20,18 +20,42 @@ class GeoPointTest extends TestCase
     /** @depends testConstructor */
     public function testLatitudeIsExpectedValue(GeoPoint $point): void
     {
-        $this->assertEquals(1.234, $point->latitude());
+        self::assertEquals(1.234, $point->latitude());
     }
 
     /** @depends testConstructor */
     public function testLongitudeIsExpectedValue(GeoPoint $point): void
     {
-        $this->assertEquals(5.678, $point->longitude());
+        self::assertEquals(5.678, $point->longitude());
     }
 
     /** @depends testConstructor */
     public function testThatGeoPointsAreNotConsideredEmpty(GeoPoint $point): void
     {
-        $this->assertFalse($point->isEmpty());
+        self::assertFalse($point->isEmpty());
+    }
+
+    public function testThatGeoPointsAreNotConsideredEmptyWithZeroValues(): void
+    {
+        $point = GeoPoint::new(0.0, 0.0);
+        self::assertFalse($point->isEmpty());
+    }
+
+    public function testThatCastingToStringYieldsExpectedFormat(): void
+    {
+        $point = GeoPoint::new(1.23, 3.21);
+        self::assertStringMatchesFormat('%f,%f', (string) $point);
+    }
+
+    public function testThatStringRepresentationUsesSixDecimalPlaces(): void
+    {
+        $point = GeoPoint::new(1.00000123, 1.00000123);
+        self::assertEquals('1.000001,1.000001', (string) $point);
+    }
+
+    public function testThatStringRepresentationPreservesSign(): void
+    {
+        $point = GeoPoint::new(-1.0, -1.0);
+        self::assertEquals('-1.000000,-1.000000', (string) $point);
     }
 }

--- a/test/Unit/Document/Fragment/SliceTest.php
+++ b/test/Unit/Document/Fragment/SliceTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrismicTest\Document\Fragment;
+
+use Prismic\Document;
+use Prismic\Document\Fragment\Collection;
+use Prismic\Document\Fragment\Factory;
+use Prismic\Document\Fragment\RichText;
+use Prismic\Document\Fragment\Slice;
+use Prismic\Document\FragmentCollection;
+use Prismic\Value\DocumentData;
+use PrismicTest\Framework\TestCase;
+use Prismic\Json;
+
+use function assert;
+
+class SliceTest extends TestCase
+{
+    /** @var FragmentCollection */
+    private $slices;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $document = DocumentData::factory(Json::decodeObject($this->jsonFixtureByFileName('basic-slices.json')));
+        $this->slices = $document->content()->get('slice-zone');
+    }
+
+    public function testThatASliceCanBeFound(): Slice
+    {
+        self::assertInstanceOf(FragmentCollection::class, $this->slices);
+        $slice = $this->slices->filter(static function (Slice $slice): bool {
+            return $slice->type() === 'custom';
+        })->first();
+        self::assertInstanceOf(Slice::class, $slice);
+
+        return $slice;
+    }
+
+    public function testThatAnEmptySliceCanBeFound(): Slice
+    {
+        self::assertInstanceOf(FragmentCollection::class, $this->slices);
+        $slice = $this->slices->filter(static function (Slice $slice): bool {
+            return $slice->type() === 'empty';
+        })->first();
+        self::assertInstanceOf(Slice::class, $slice);
+
+        return $slice;
+    }
+
+    /** @depends testThatASliceCanBeFound */
+    public function testThatTheLabelIsTheExpectedValue(Slice $slice): void
+    {
+        self::assertEquals('custom-label', $slice->label());
+    }
+
+    /** @depends testThatASliceCanBeFound */
+    public function testThatTheSliceIsNotEmpty(Slice $slice): void
+    {
+        self::assertFalse($slice->isEmpty());
+    }
+
+    /** @depends testThatAnEmptySliceCanBeFound */
+    public function testThatTheEmptySliceIsEmpty(Slice $slice): void
+    {
+        self::assertTrue($slice->isEmpty());
+    }
+
+    /** @depends testThatASliceCanBeFound */
+    public function testThatToStringWillYieldTheExpectedValue(Slice $slice): void
+    {
+        $expect = <<<TEXT
+            Heading 1
+            Heading 2
+            42
+            Some Text
+            43
+            More Text
+            TEXT;
+
+        self::assertEquals($expect, (string) $slice);
+    }
+
+    /** @depends testThatAnEmptySliceCanBeFound */
+    public function testThatTheEmptySliceIsAnEmptyStringWhenCastToAString(Slice $slice): void
+    {
+        self::assertEquals('', (string) $slice);
+    }
+}

--- a/test/Unit/Document/Fragment/SliceTest.php
+++ b/test/Unit/Document/Fragment/SliceTest.php
@@ -4,17 +4,11 @@ declare(strict_types=1);
 
 namespace PrismicTest\Document\Fragment;
 
-use Prismic\Document;
-use Prismic\Document\Fragment\Collection;
-use Prismic\Document\Fragment\Factory;
-use Prismic\Document\Fragment\RichText;
 use Prismic\Document\Fragment\Slice;
 use Prismic\Document\FragmentCollection;
+use Prismic\Json;
 use Prismic\Value\DocumentData;
 use PrismicTest\Framework\TestCase;
-use Prismic\Json;
-
-use function assert;
 
 class SliceTest extends TestCase
 {

--- a/test/Unit/Document/Fragment/TextElementTest.php
+++ b/test/Unit/Document/Fragment/TextElementTest.php
@@ -145,4 +145,10 @@ class TextElementTest extends TestCase
         self::assertSame($ordered, $item->isOrderedListItem());
         self::assertSame($unordered, $item->isUnorderedListItem());
     }
+
+    public function testThatTextElementsCanBeCastToAString(): void
+    {
+        $item = TextElement::new(TextElement::TYPE_HEADING1, 'Heading', [], null);
+        self::assertEquals('Heading', (string) $item);
+    }
 }

--- a/test/Unit/Value/LanguageTest.php
+++ b/test/Unit/Value/LanguageTest.php
@@ -12,7 +12,13 @@ class LanguageTest extends TestCase
     public function testExpectedBehaviour(): void
     {
         $lang = Language::new('foo', 'bar');
-        $this->assertSame('foo', $lang->id());
-        $this->assertSame('bar', $lang->name());
+        self::assertSame('foo', $lang->id());
+        self::assertSame('bar', $lang->name());
+    }
+
+    public function testThatCastingToStringYieldsTheLanguageCode(): void
+    {
+        $language = Language::new('en-gb', 'The Queens English');
+        self::assertEquals('en-gb', (string) $language);
     }
 }

--- a/test/Unit/Value/TypeTest.php
+++ b/test/Unit/Value/TypeTest.php
@@ -16,15 +16,21 @@ class TypeTest extends TestCase
     public function testNewInstance(): void
     {
         $type = Type::new('foo', 'bar');
-        $this->assertEquals('foo', $type->id());
-        $this->assertEquals('bar', $type->name());
+        self::assertEquals('foo', $type->id());
+        self::assertEquals('bar', $type->name());
     }
 
     public function testJsonEncode(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             '{"foo":"bar"}',
             json_encode(Type::new('foo', 'bar'), JSON_THROW_ON_ERROR)
         );
+    }
+
+    public function testThatTheStringValueIsTheTypeIdentifier(): void
+    {
+        $type = Type::new('foo', 'bar');
+        self::assertEquals('foo', (string) $type);
     }
 }

--- a/test/fixture/basic-slices.json
+++ b/test/fixture/basic-slices.json
@@ -1,0 +1,51 @@
+{
+    "id": "document-id",
+    "uid": "document-uid",
+    "type": "custom-type",
+    "href": "https://repo.cdn.prismic.io/api/v2/documents/search?ref=master-ref&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22document-id%22%29+%5D%5D",
+    "tags": [],
+    "first_publication_date": "2020-01-01T01:23:45+0000",
+    "last_publication_date": "2020-01-01T01:23:45+0000",
+    "slugs": [],
+    "linked_documents": [],
+    "lang": "en-gb",
+    "alternate_languages": [],
+    "data": {
+        "slice-zone": [
+            {
+                "slice_type": "custom",
+                "slice_label": "custom-label",
+                "items": [
+                    {
+                        "number": 42,
+                        "plain": "Some Text"
+                    },
+                    {
+                        "number": 43,
+                        "plain": "More Text"
+                    }
+                ],
+                "primary": {
+                    "content": [
+                        {
+                            "type": "heading1",
+                            "text": "Heading 1",
+                            "spans": []
+                        },
+                        {
+                            "type": "heading2",
+                            "text": "Heading 2",
+                            "spans": []
+                        }
+                    ]
+                }
+            },
+            {
+                "slice_type": "empty",
+                "slice_label": null,
+                "items": [],
+                "primary": {}
+            }
+        ]
+    }
+}


### PR DESCRIPTION
It's frequently helpful to be able to cast values to simple strings.

Where appropriate, `__toString()` has been introduced on types that didn't previously support string casting.