### PR TITLE
Feature: Retrying client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#68](https://github.com/netglue/prismic-client/pull/68) adds the `Prismic\RetryingClient`. This proxy client decorates an existing client and retries queries that fail against a preview ref or a release ref against the master ref and stores the previous exception for inspection. The main use-case for this feature is so that you can more easily catch `PreviewTokenExpired` exceptions when it is not possible to catch them in an HTTP request/response cycle. For example, when you are querying the repo in order to set up routes before a request has been dispatched. An example middleware might inspect the client for its `lastRequestFailure()` and destroy the preview request cookie when the exception is of the type `PreviewTokenExpired`.
 
 ### Changed
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.8.1@f73f2299dbc59a3e6c4d66cff4605176e728ee69">
+<files psalm-version="4.12.0@e42bc4a23f67acba28a23bb09c348e2ff38a1d87">
   <file src="src/Api.php">
     <InvalidCatch occurrences="2"/>
     <InvalidScalarArgument occurrences="1">
@@ -11,22 +11,17 @@
     <MissingClosureReturnType occurrences="1">
       <code>static function ($given, callable $locator, string $message) {</code>
     </MissingClosureReturnType>
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="5">
       <code>$data['body'] ?? null</code>
-      <code>$decodedPayload</code>
       <code>$responseBody-&gt;mainDocument</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="1">
       <code>$data['body']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$data</code>
-      <code>$decodedPayload</code>
       <code>$params[$parameter]</code>
     </MixedAssignment>
-    <MixedPropertyTypeCoercion occurrences="1">
-      <code>$_COOKIE ?? []</code>
-    </MixedPropertyTypeCoercion>
     <PossiblyNullArgument occurrences="3">
       <code>$data['body'] ?? null</code>
       <code>$resultSet-&gt;nextPage()</code>
@@ -35,12 +30,6 @@
     <PossiblyNullReference occurrences="1">
       <code>save</code>
     </PossiblyNullReference>
-    <RedundantCondition occurrences="1">
-      <code>$_COOKIE</code>
-    </RedundantCondition>
-    <TypeDoesNotContainNull occurrences="1">
-      <code>[]</code>
-    </TypeDoesNotContainNull>
   </file>
   <file src="src/Document/Fragment/BaseCollection.php">
     <UnsafeInstantiation occurrences="2">
@@ -78,11 +67,6 @@
     <MixedArgument occurrences="1">
       <code>$fragment</code>
     </MixedArgument>
-  </file>
-  <file src="src/Exception/PreviewTokenExpired.php">
-    <MixedAssignment occurrences="1">
-      <code>$error</code>
-    </MixedAssignment>
   </file>
   <file src="src/Predicate.php">
     <MixedArgument occurrences="3">
@@ -140,22 +124,13 @@
     <PossiblyFalsePropertyAssignmentValue occurrences="1"/>
   </file>
   <file src="src/Serializer/HtmlSerializer.php">
-    <MissingClosureParamType occurrences="1">
-      <code>$character</code>
-    </MissingClosureParamType>
-    <MixedArgument occurrences="4">
-      <code>$character</code>
+    <MixedArgument occurrences="1">
       <code>$item</code>
-      <code>$nodes[$end]</code>
-      <code>$nodes[$start]</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1"/>
     <MixedAssignment occurrences="1">
       <code>$item</code>
     </MixedAssignment>
-    <PossiblyNullArgument occurrences="1">
-      <code>$embed-&gt;html()</code>
-    </PossiblyNullArgument>
     <RedundantCondition occurrences="10">
       <code>assert($fragment instanceof BooleanFragment)</code>
       <code>assert($fragment instanceof Color)</code>
@@ -168,19 +143,6 @@
       <code>assert($fragment instanceof StringFragment)</code>
       <code>assert($fragment instanceof TextElement)</code>
     </RedundantCondition>
-  </file>
-  <file src="src/Value/ApiData.php">
-    <MixedArgument occurrences="1">
-      <code>$tags</code>
-    </MixedArgument>
-    <PropertyNotSetInConstructor occurrences="6">
-      <code>$bookmarks</code>
-      <code>$forms</code>
-      <code>$languages</code>
-      <code>$refs</code>
-      <code>$tags</code>
-      <code>$types</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="src/Value/DataAssertionBehaviour.php">
     <MixedInferredReturnType occurrences="5">
@@ -284,12 +246,7 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/Unit/PredicateTest.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>true</code>
-    </InvalidScalarArgument>
-    <MixedArgument occurrences="11">
-      <code>$high</code>
-      <code>$low</code>
+    <MixedArgument occurrences="1">
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -300,18 +257,6 @@
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="6">
-      <code>mixed[]</code>
-      <code>mixed[]</code>
-      <code>mixed[]</code>
-      <code>mixed[]</code>
-      <code>mixed[]</code>
-      <code>mixed[]</code>
-      <code>mixed[]</code>
-    </MixedInferredReturnType>
-    <PossiblyFalseArgument occurrences="1">
-      <code>false</code>
-    </PossiblyFalseArgument>
     <TypeDoesNotContainType occurrences="1">
       <code>assert($rehydrated instanceof Predicate)</code>
     </TypeDoesNotContainType>

--- a/src/RetryingClient.php
+++ b/src/RetryingClient.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prismic;
+
+use Prismic\Document\Fragment\DocumentLink;
+use Prismic\Exception\RequestFailure;
+use Prismic\Value\ApiData;
+use Prismic\Value\Ref;
+
+/**
+ * @psalm-suppress DeprecatedMethod
+ */
+final class RetryingClient implements ApiClient
+{
+    /** @var ApiClient */
+    private $wrappedClient;
+
+    /** @var RequestFailure|null */
+    private $lastException;
+
+    private function __construct(ApiClient $client)
+    {
+        $this->wrappedClient = $client;
+    }
+
+    public function lastRequestFailure(): ?RequestFailure
+    {
+        return $this->lastException instanceof RequestFailure ? $this->lastException : null;
+    }
+
+    public static function wrap(ApiClient $client): self
+    {
+        return new self($client);
+    }
+
+    public function host(): string
+    {
+        return $this->wrappedClient->host();
+    }
+
+    public function data(): ApiData
+    {
+        return $this->wrappedClient->data();
+    }
+
+    public function ref(): Ref
+    {
+        return $this->wrappedClient->ref();
+    }
+
+    public function createQuery(string $form = self::DEFAULT_FORM): Query
+    {
+        return $this->wrappedClient->createQuery($form);
+    }
+
+    public function query(Query $query): ResultSet
+    {
+        $this->lastException = null;
+        try {
+            return $this->wrappedClient->query($query);
+        } catch (RequestFailure $error) {
+            $this->lastException = $error;
+            if ($this->ref()->isMaster()) {
+                throw $error;
+            }
+
+            return $this->wrappedClient->query(
+                $query->ref($this->data()->master())
+            );
+        }
+    }
+
+    public function queryFirst(Query $query): ?Document
+    {
+        return $this->wrappedClient->queryFirst($query);
+    }
+
+    public function findById(string $id): ?Document
+    {
+        return $this->wrappedClient->findById($id);
+    }
+
+    public function findByUid(string $type, string $uid, string $lang = '*'): ?Document
+    {
+        return $this->wrappedClient->findByUid($type, $uid, $lang);
+    }
+
+    public function findByBookmark(string $bookmark): ?Document
+    {
+        return $this->wrappedClient->findByBookmark($bookmark);
+    }
+
+    public function findAll(Query $query): ResultSet
+    {
+        return $this->wrappedClient->findAll($query);
+    }
+
+    public function next(ResultSet $resultSet): ?ResultSet
+    {
+        return $this->wrappedClient->next($resultSet);
+    }
+
+    public function previous(ResultSet $resultSet): ?ResultSet
+    {
+        return $this->wrappedClient->previous($resultSet);
+    }
+
+    /** @inheritDoc */
+    public function setRequestCookies(array $cookies): void
+    {
+        $this->wrappedClient->setRequestCookies($cookies);
+    }
+
+    public function inPreview(): bool
+    {
+        return $this->wrappedClient->inPreview();
+    }
+
+    public function previewSession(string $token): ?DocumentLink
+    {
+        return $this->wrappedClient->previewSession($token);
+    }
+}

--- a/test/Unit/RetryingClientTest.php
+++ b/test/Unit/RetryingClientTest.php
@@ -117,6 +117,7 @@ class RetryingClientTest extends TestCase
             });
 
         self::assertSame($results, $this->client->query($query));
+        self::assertSame($exception, $this->client->lastRequestFailure());
     }
 
     public function testThatHostMethodProxiesToWrappedClient(): void

--- a/test/Unit/RetryingClientTest.php
+++ b/test/Unit/RetryingClientTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrismicTest;
+
+use Laminas\Diactoros\Response\TextResponse;
+use Laminas\Diactoros\ServerRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use Prismic\ApiClient;
+use Prismic\Exception\RequestFailure;
+use Prismic\Json;
+use Prismic\Query;
+use Prismic\ResultSet;
+use Prismic\ResultSet\StandardResultSet;
+use Prismic\RetryingClient;
+use Prismic\Value\ApiData;
+use Prismic\Value\Ref;
+use PrismicTest\Framework\TestCase;
+use Throwable;
+
+/**
+ * @psalm-suppress DeprecatedMethod
+ */
+class RetryingClientTest extends TestCase
+{
+    /** @var RetryingClient */
+    private $client;
+    /** @var MockObject&ApiClient */
+    private $wrappedClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->wrappedClient = $this->createMock(ApiClient::class);
+        $this->client = RetryingClient::wrap($this->wrappedClient);
+    }
+
+    public function testThatTheLastExceptionIsInitiallyNull(): void
+    {
+        self::assertNull($this->client->lastRequestFailure());
+    }
+
+    private function emptyResultSet(): StandardResultSet
+    {
+        return StandardResultSet::factory(Json::decodeObject($this->jsonFixtureByFileName('empty-result-set.json')));
+    }
+
+    public function testThatTheLastExceptionWillBeNullWhenTheQueryExecutesWithoutAnError(): void
+    {
+        $query = $this->createQuery();
+        $results = $this->emptyResultSet();
+
+        $this->wrappedClient->expects(self::once())
+            ->method('query')
+            ->with(self::identicalTo($query))
+            ->willReturn($results);
+
+        self::assertSame($results, $this->client->query($query));
+        self::assertNull($this->client->lastRequestFailure());
+    }
+
+    public function testThatErrorsAreStillThrownWhenTheUsedRefIsTheMaster(): void
+    {
+        $master = Ref::new('foo', 'foo', 'foo', true);
+        $query = $this->createQuery();
+        $exception = RequestFailure::withClientError(new ServerRequest(), new TextResponse('[]'));
+
+        $this->wrappedClient->expects(self::once())
+            ->method('ref')
+            ->willReturn($master);
+
+        $this->wrappedClient->expects(self::once())
+            ->method('query')
+            ->with(self::identicalTo($query))
+            ->willThrowException($exception);
+
+        try {
+            $this->client->query($query);
+            $this->fail('An exception was not thrown');
+        } catch (Throwable $error) {
+            self::assertSame($exception, $error);
+        }
+    }
+
+    public function testThatWhenARequestFailureOccursTheQueryIsRetriedWithTheMasterRef(): void
+    {
+        $results = $this->emptyResultSet();
+        $data = ApiData::factory(Json::decodeObject($this->jsonFixtureByFileName('api-data.json')));
+        $usedRef = Ref::new('not-master', 'foo', 'foo', false);
+        $query = $this->createQuery()->ref($usedRef);
+        $exception = RequestFailure::withClientError(new ServerRequest(), new TextResponse('[]'));
+        $matcher = self::exactly(2);
+
+        $this->wrappedClient->expects(self::once())
+            ->method('ref')
+            ->willReturn($usedRef);
+
+        $this->wrappedClient->expects(self::once())
+            ->method('data')
+            ->willReturn($data);
+
+        $this->wrappedClient->expects($matcher)
+            ->method('query')
+            ->with(self::isInstanceOf(Query::class))
+            ->willReturnCallback(static function (Query $queryInput) use ($data, $results, $exception, $query, $matcher): ResultSet {
+                /** @psalm-suppress InternalMethod */
+                if ($matcher->getInvocationCount() === 1) {
+                    throw $exception;
+                }
+
+                self::assertNotSame($query, $queryInput, 'The query should be modified on the second invocation and was not');
+                self::assertStringContainsString($data->master()->ref(), $queryInput->toUrl(), 'The query for the second invocation should use the master ref');
+
+                return $results;
+            });
+
+        self::assertSame($results, $this->client->query($query));
+    }
+
+    public function testThatHostMethodProxiesToWrappedClient(): void
+    {
+        $this->wrappedClient->expects(self::once())
+            ->method('host')
+            ->willReturn('goats');
+
+        self::assertEquals('goats', $this->client->host());
+    }
+
+    public function testThatDataMethodProxiesToWrappedClient(): void
+    {
+        $data = ApiData::factory(Json::decodeObject($this->jsonFixtureByFileName('api-data.json')));
+
+        $this->wrappedClient->expects(self::once())
+            ->method('data')
+            ->willReturn($data);
+
+        self::assertSame($data, $this->client->data());
+    }
+
+    public function testThatRefMethodProxiesToWrappedClient(): void
+    {
+        $ref = Ref::new('whatever', 'whatever', 'whatever', false);
+        $this->wrappedClient->expects(self::once())
+            ->method('ref')
+            ->willReturn($ref);
+
+        self::assertSame($ref, $this->client->ref());
+    }
+
+    private function createQuery(): Query
+    {
+        $data = ApiData::factory(Json::decodeObject($this->jsonFixtureByFileName('api-data.json')));
+        $formName = 'some-collection';
+        $form = $data->form($formName);
+
+        return new Query($form);
+    }
+
+    public function testThatCreateQueryMethodProxiesToWrappedClient(): void
+    {
+        $query = $this->createQuery();
+
+        $this->wrappedClient->expects(self::once())
+            ->method('createQuery')
+            ->with('some-collection')
+            ->willReturn($query);
+
+        self::assertSame($query, $this->client->createQuery('some-collection'));
+    }
+
+    public function testThatQueryFirstProxiesToWrappedClient(): void
+    {
+        $query = $this->createQuery();
+
+        $this->wrappedClient->expects(self::once())
+            ->method('queryFirst')
+            ->with(self::identicalTo($query))
+            ->willReturn(null);
+
+        self::assertNull($this->client->queryFirst($query));
+    }
+
+    public function testThatFindByIdProxiesToTheWrappedClient(): void
+    {
+        $this->wrappedClient->expects(self::once())
+            ->method('findById')
+            ->with(self::equalTo('goats'))
+            ->willReturn(null);
+
+        self::assertNull($this->client->findById('goats'));
+    }
+
+    public function testThatFindByUidProxiesToTheWrappedClient(): void
+    {
+        $this->wrappedClient->expects(self::once())
+            ->method('findByUid')
+            ->with(
+                self::equalTo('type'),
+                self::equalTo('uid'),
+                self::equalTo('lang')
+            )
+            ->willReturn(null);
+
+        self::assertNull($this->client->findByUid('type', 'uid', 'lang'));
+    }
+
+    public function testThatCookiesAreProvidedToWrappedClient(): void
+    {
+        $cookies = ['foo' => 'bar'];
+        $this->wrappedClient->expects(self::once())
+            ->method('setRequestCookies')
+            ->with(self::equalTo($cookies));
+
+        $this->client->setRequestCookies($cookies);
+    }
+
+    public function testThatInPreviewProxiesToWrappedClient(): void
+    {
+        $this->wrappedClient->expects(self::once())
+            ->method('inPreview')
+            ->willReturn(true);
+
+        self::assertTrue($this->client->inPreview());
+    }
+
+    public function testThatPreviewSessionProxiesToWrappedClient(): void
+    {
+        $this->wrappedClient->expects(self::once())
+            ->method('previewSession')
+            ->with('foo-bar')
+            ->willReturn(null);
+
+        self::assertNull($this->client->previewSession('foo-bar'));
+    }
+
+    public function testThatFindByBookmarkProxiesToWrappedClient(): void
+    {
+        $this->wrappedClient->expects(self::once())
+            ->method('findByBookmark')
+            ->with('foo-bar')
+            ->willReturn(null);
+
+        self::assertNull($this->client->findByBookmark('foo-bar'));
+    }
+
+    public function testThatFindAllProxiesToWrappedClient(): void
+    {
+        $resultSet = $this->emptyResultSet();
+        $query = $this->createQuery();
+
+        $this->wrappedClient->expects(self::once())
+            ->method('findAll')
+            ->with(self::identicalTo($query))
+            ->willReturn($resultSet);
+
+        self::assertSame($resultSet, $this->client->findAll($query));
+    }
+
+    public function testThatNextProxiesToWrappedClient(): void
+    {
+        $resultSet = $this->emptyResultSet();
+        $this->wrappedClient->expects(self::once())
+            ->method('next')
+            ->with(self::identicalTo($resultSet))
+            ->willReturn(null);
+
+        self::assertNull($this->client->next($resultSet));
+    }
+
+    public function testThatPreviousProxiesToWrappedClient(): void
+    {
+        $resultSet = $this->emptyResultSet();
+        $this->wrappedClient->expects(self::once())
+            ->method('previous')
+            ->with(self::identicalTo($resultSet))
+            ->willReturn(null);
+
+        self::assertNull($this->client->previous($resultSet));
+    }
+}

--- a/test/fixture/empty-result-set.json
+++ b/test/fixture/empty-result-set.json
@@ -1,0 +1,9 @@
+{
+    "page": 1,
+    "results_per_page": 20,
+    "total_results_size": 0,
+    "total_pages": 0,
+    "next_page": null,
+    "prev_page": null,
+    "results": []
+}


### PR DESCRIPTION
Adds an alternative client implementation that wraps a standard client and retries queries against the master ref when a query against a release or preview ref fails with a `RequestFailure`.

The main use case for this proxy client is for handling preview expired exceptions that you can't catch further up in your stack because you're using information from the CMS to configure routing for example when your app fires up.

The client has an additional method `lastRequestFailure()` that you can check for any failures and kill preview cookies in your front end when the failure represents a `PreviewTokenExpired` exception for example.
