### PR TITLE
Psalm - Iterable type fixes

### DIFF
--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -9,7 +9,8 @@ use IteratorAggregate;
 use Traversable;
 
 /**
- * @template-implements IteratorAggregate<array-key, Document>
+ * @template T of Document
+ * @template-implements IteratorAggregate<T>
  */
 interface ResultSet extends IteratorAggregate, Countable
 {
@@ -46,19 +47,21 @@ interface ResultSet extends IteratorAggregate, Countable
     /**
      * Return the document results as an array
      *
-     * @return Document[]
+     * @return list<T>
      */
     public function results(): array;
 
     /**
      * Retrieve an iterator for iterating over results
      *
-     * @return Traversable<array-key, Document>
+     * @return Traversable<array-key, T>
      */
     public function getIterator(): Traversable;
 
     /**
      * Return the first document in the result set or null if the result set is empty
+     *
+     * @psalm-return T|null
      */
     public function first(): ?Document;
 
@@ -68,6 +71,10 @@ interface ResultSet extends IteratorAggregate, Countable
      * The primary purpose of this method is to collect paginated results into a single response and should not be used
      * to merge unrelated result sets in {@link Api::findAll()}. If you need to combine results yourself, just use
      * $combined = array_merge($response1->results(), $response2->results());
+     *
+     * @param self<T> $with
+     *
+     * @return self<T>
      */
     public function merge(self $with): self;
 }

--- a/src/ResultSet/StandardResultSet.php
+++ b/src/ResultSet/StandardResultSet.php
@@ -24,9 +24,14 @@ use function max;
 use function preg_match;
 use function sprintf;
 
+/**
+ * @template T of Document
+ * @template-implements ResultSet<T>
+ */
 final class StandardResultSet implements ResultSet
 {
     use DataAssertionBehaviour;
+    /** @use TypicalResultSetBehaviour<T> */
     use TypicalResultSetBehaviour;
 
     /** @var DateTimeImmutable|null */
@@ -35,7 +40,7 @@ final class StandardResultSet implements ResultSet
     /** @var int|null */
     private $maxAge;
 
-    /** @param array<array-key, Document> $results */
+    /** @param list<T> $results */
     private function __construct(
         int $page,
         int $perPage,
@@ -72,6 +77,7 @@ final class StandardResultSet implements ResultSet
 
     public static function factory(object $data): self
     {
+        /** @psalm-var list<DocumentData> $results */
         $results = array_map(static function (object $document): Document {
             return DocumentData::factory($document);
         }, self::assertObjectPropertyIsArray($data, 'results'));

--- a/src/ResultSet/TypicalResultSetBehaviour.php
+++ b/src/ResultSet/TypicalResultSetBehaviour.php
@@ -1,12 +1,10 @@
 <?php
-/** @noinspection PhpUnusedAliasInspection */
 
 declare(strict_types=1);
 
 namespace Prismic\ResultSet;
 
 use ArrayIterator;
-use IteratorAggregate;
 use Prismic\Document;
 use Traversable;
 
@@ -14,11 +12,11 @@ use function count;
 use function reset;
 
 /**
- * @template T of IteratorAggregate<array-key, Document>
+ * @template T of Document
  */
 trait TypicalResultSetBehaviour
 {
-    /** @var array<array-key, Document> */
+    /** @var list<T> */
     private $results;
 
     /** @var int */
@@ -69,18 +67,19 @@ trait TypicalResultSetBehaviour
         return $this->prevPage;
     }
 
-    /** @return Document[] */
+    /** @return list<T> */
     public function results(): array
     {
         return $this->results;
     }
 
-    /** @return Traversable<array-key, Document> */
+    /** @return Traversable<array-key, T> */
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->results);
     }
 
+    /** @psalm-return T|null */
     public function first(): ?Document
     {
         $first = reset($this->results);


### PR DESCRIPTION
Fixes iterable types for psalm so that implementors can apply their own types to ResultSet with ResultSet<Foo>