### PR TITLE
Fix Unauthenticated Pagination URIs

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -328,7 +328,7 @@ final class Api implements ApiClient
     private function uriWithQueryValue(UriInterface $uri, string $parameter, $value): UriInterface
     {
         $params = [];
-        parse_str((string) $uri, $params);
+        parse_str($uri->getQuery(), $params);
         $params[$parameter] = $value;
 
         return $uri->withQuery(http_build_query($params));
@@ -442,10 +442,13 @@ final class Api implements ApiClient
             return null;
         }
 
+        $uri = $this->uriFactory->createUri(urldecode($nextPage));
+        if ($this->accessToken !== null) {
+            $uri = $this->uriWithQueryValue($uri, 'access_token', $this->accessToken);
+        }
+
         return $this->resultSetFactory->withJsonObject(
-            $this->jsonResponse(
-                $this->uriFactory->createUri($nextPage)
-            )
+            $this->jsonResponse($uri)
         );
     }
 
@@ -456,10 +459,13 @@ final class Api implements ApiClient
             return null;
         }
 
+        $uri = $this->uriFactory->createUri(urldecode($previousPage));
+        if ($this->accessToken !== null) {
+            $uri = $this->uriWithQueryValue($uri, 'access_token', $this->accessToken);
+        }
+
         return $this->resultSetFactory->withJsonObject(
-            $this->jsonResponse(
-                $this->uriFactory->createUri($previousPage)
-            )
+            $this->jsonResponse($uri)
         );
     }
 

--- a/test/fixture/paginated-result-set.json
+++ b/test/fixture/paginated-result-set.json
@@ -1,0 +1,25 @@
+{
+    "page": 2,
+    "results_per_page": 1,
+    "results_size": 1,
+    "total_results_size": 5,
+    "total_pages": 5,
+    "next_page": "https://example.com/api/v2/documents/search?ref=expect-ref&q=%5B%5Bat%28document.type%2C+%22page%22%29%5D%5D&page=3&pageSize=1",
+    "prev_page": "https://example.com/api/v2/documents/search?ref=expect-ref&q=%5B%5Bat%28document.type%2C+%22page%22%29%5D%5D&page=1&pageSize=1",
+    "results": [
+        {
+            "id": "foo",
+            "uid": "example",
+            "type": "page",
+            "href": "https://example.com",
+            "tags": [],
+            "first_publication_date": "2017-12-13T22:57:54+0000",
+            "last_publication_date": "2022-05-24T07:31:02+0000",
+            "slugs": [],
+            "linked_documents": [],
+            "lang": "en-gb",
+            "alternate_languages": [],
+            "data": {}
+        }
+    ]
+}


### PR DESCRIPTION
Paginated result sets do not include the access token given in the initial request for the next/previous page uris - Appends the configured access token to these URIs if it is present.

Fixes #159 