### PR TITLE
Update doctrine coding standard to ^10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "doctrine/coding-standard": "^9.0",
+        "doctrine/coding-standard": "^10.0",
         "laminas/laminas-diactoros": "^2.13.0",
         "maglnet/composer-require-checker": "^3.8.0",
         "php-http/cache-plugin": "^1.7",
@@ -56,7 +56,7 @@
         "squizlabs/php_codesniffer": "^3.7.1",
         "symfony/cache": "^5.4 || ^6.0.0",
         "symfony/options-resolver": "^5.4 || ^6.0",
-        "vimeo/psalm": "^4.24.0"
+        "vimeo/psalm": "^4.26.0"
     },
     "scripts": {
         "check": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e8521e5954473d232ee5cd5b91fb9e3",
+    "content-hash": "0281023731bd3e60566cd399ea44e684",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -795,16 +795,16 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v5.4.3",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "cc1147cb11af1b43f503ac18f31aa3bec213aba8"
+                "reference": "54f14e36aa73cb8f7261d7686691fd4d75ea2690"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/cc1147cb11af1b43f503ac18f31aa3bec213aba8",
-                "reference": "cc1147cb11af1b43f503ac18f31aa3bec213aba8",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/54f14e36aa73cb8f7261d7686691fd4d75ea2690",
+                "reference": "54f14e36aa73cb8f7261d7686691fd4d75ea2690",
                 "shasum": ""
             },
             "require": {
@@ -844,7 +844,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v5.4.3"
+                "source": "https://github.com/symfony/options-resolver/tree/v5.4.11"
             },
             "funding": [
                 {
@@ -860,7 +860,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2022-07-20T13:00:38+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -1597,23 +1597,23 @@
         },
         {
             "name": "doctrine/coding-standard",
-            "version": "9.0.0",
+            "version": "10.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/coding-standard.git",
-                "reference": "35a2452c6025cb739c3244b3348bcd1604df07d1"
+                "reference": "7903671d7d33c231c8921058b7c14b8f57cbacb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/35a2452c6025cb739c3244b3348bcd1604df07d1",
-                "reference": "35a2452c6025cb739c3244b3348bcd1604df07d1",
+                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/7903671d7d33c231c8921058b7c14b8f57cbacb7",
+                "reference": "7903671d7d33c231c8921058b7c14b8f57cbacb7",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-                "php": "^7.1 || ^8.0",
-                "slevomat/coding-standard": "^7.0.0",
-                "squizlabs/php_codesniffer": "^3.6.0"
+                "php": "^7.2 || ^8.0",
+                "slevomat/coding-standard": "^8.2",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1646,9 +1646,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/coding-standard/issues",
-                "source": "https://github.com/doctrine/coding-standard/tree/9.0.0"
+                "source": "https://github.com/doctrine/coding-standard/tree/10.0.0"
             },
-            "time": "2021-04-12T15:11:14+00:00"
+            "time": "2022-08-26T10:53:05+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1823,25 +1823,24 @@
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.13.0",
+            "version": "2.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "34ba65010be9aa74e159d168c5ecfa5c01e4d956"
+                "reference": "49f3f7a3b30ff5a0e62e9b5d16584451f59de65c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/34ba65010be9aa74e159d168c5ecfa5c01e4d956",
-                "reference": "34ba65010be9aa74e159d168c5ecfa5c01e4d956",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/49f3f7a3b30ff5a0e62e9b5d16584451f59de65c",
+                "reference": "49f3f7a3b30ff5a0e62e9b5d16584451f59de65c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0"
             },
             "conflict": {
-                "phpspec/prophecy": "<1.9.0",
                 "zendframework/zend-diactoros": "*"
             },
             "provide": {
@@ -1854,10 +1853,9 @@
                 "ext-gd": "*",
                 "ext-libxml": "*",
                 "http-interop/http-factory-tests": "^0.9.0",
-                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-coding-standard": "^2.4.0",
                 "php-http/psr7-integration-tests": "^1.1.1",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^9.5.23",
                 "psalm/plugin-phpunit": "^0.17.0",
                 "vimeo/psalm": "^4.24.0"
             },
@@ -1918,7 +1916,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-07-07T12:31:03+00:00"
+            "time": "2022-08-28T21:10:44+00:00"
         },
         {
             "name": "maglnet/composer-require-checker",
@@ -2693,84 +2691,17 @@
             "time": "2022-03-15T21:29:03+00:00"
         },
         {
-            "name": "phpspec/prophecy",
-            "version": "v1.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
-                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.2",
-                "phpdocumentor/reflection-docblock": "^5.2",
-                "sebastian/comparator": "^3.0 || ^4.0",
-                "sebastian/recursion-context": "^3.0 || ^4.0"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^6.0 || ^7.0",
-                "phpunit/phpunit": "^8.0 || ^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Prophecy\\": "src/Prophecy"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
-                }
-            ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "support": {
-                "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
-            },
-            "time": "2021-12-08T12:19:24+00:00"
-        },
-        {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.6.4",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "135607f9ccc297d6923d49c2bcf309f509413215"
+                "reference": "367a8d9d5f7da2a0136422d27ce8840583926955"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/135607f9ccc297d6923d49c2bcf309f509413215",
-                "reference": "135607f9ccc297d6923d49c2bcf309f509413215",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/367a8d9d5f7da2a0136422d27ce8840583926955",
+                "reference": "367a8d9d5f7da2a0136422d27ce8840583926955",
                 "shasum": ""
             },
             "require": {
@@ -2800,29 +2731,29 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.4"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.7.0"
             },
-            "time": "2022-06-26T13:09:08+00:00"
+            "time": "2022-08-09T12:23:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.15",
+            "version": "9.2.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f"
+                "reference": "2593003befdcc10db5e213f9f28814f5aa8ac073"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
-                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2593003befdcc10db5e213f9f28814f5aa8ac073",
+                "reference": "2593003befdcc10db5e213f9f28814f5aa8ac073",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.13.0",
+                "nikic/php-parser": "^4.14",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -2871,7 +2802,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.15"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.16"
             },
             "funding": [
                 {
@@ -2879,7 +2810,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-07T09:28:20+00:00"
+            "time": "2022-08-20T05:26:47+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3124,16 +3055,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.21",
+            "version": "9.5.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1"
+                "reference": "888556852e7e9bbeeedb9656afe46118765ade34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e32b76be457de00e83213528f6bb37e2a38fcb1",
-                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/888556852e7e9bbeeedb9656afe46118765ade34",
+                "reference": "888556852e7e9bbeeedb9656afe46118765ade34",
                 "shasum": ""
             },
             "require": {
@@ -3148,7 +3079,6 @@
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
-                "phpspec/prophecy": "^1.12.1",
                 "phpunit/php-code-coverage": "^9.2.13",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
@@ -3165,9 +3095,6 @@
                 "sebastian/resource-operations": "^3.0.3",
                 "sebastian/type": "^3.0",
                 "sebastian/version": "^3.0.2"
-            },
-            "require-dev": {
-                "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
                 "ext-soap": "*",
@@ -3210,7 +3137,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.21"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.23"
             },
             "funding": [
                 {
@@ -3222,7 +3149,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-19T12:14:25+00:00"
+            "time": "2022-08-22T14:01:36+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3388,18 +3315,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "bc4d989050885c9c2138e0da74519efaad597076"
+                "reference": "bd4a45f60f097f0c44f77c6d72caa24ebc9b9f66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/bc4d989050885c9c2138e0da74519efaad597076",
-                "reference": "bc4d989050885c9c2138e0da74519efaad597076",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/bd4a45f60f097f0c44f77c6d72caa24ebc9b9f66",
+                "reference": "bd4a45f60f097f0c44f77c6d72caa24ebc9b9f66",
                 "shasum": ""
             },
             "conflict": {
                 "3f/pygmentize": "<1.2",
                 "admidio/admidio": "<4.1.9",
                 "adodb/adodb-php": "<=5.20.20|>=5.21,<=5.21.3",
+                "aheinze/cockpit": "<=2.2.1",
                 "akaunting/akaunting": "<2.1.13",
                 "alextselegidis/easyappointments": "<=1.4.3",
                 "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
@@ -3443,6 +3371,7 @@
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
                 "codeigniter/framework": "<=3.0.6",
                 "codeigniter4/framework": "<4.1.9",
+                "codeigniter4/shield": "= 1.0.0-beta",
                 "codiad/codiad": "<=2.8.4",
                 "composer/composer": "<1.10.26|>=2-alpha.1,<2.2.12|>=2.3,<2.3.5",
                 "concrete5/concrete5": "<9",
@@ -3455,7 +3384,7 @@
                 "contao/managed-edition": "<=1.5",
                 "craftcms/cms": "<3.7.36",
                 "croogo/croogo": "<3.0.7",
-                "cuyz/valinor": ">=0.5,<0.7",
+                "cuyz/valinor": "<0.12",
                 "czproject/git-php": "<4.0.3",
                 "darylldoyle/safe-svg": "<1.9.10",
                 "datadog/dd-trace": ">=0.30,<0.30.2",
@@ -3473,7 +3402,7 @@
                 "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
                 "dolibarr/dolibarr": "<16|= 12.0.5|>= 3.3.beta1, < 13.0.2",
                 "dompdf/dompdf": "<2",
-                "drupal/core": ">=7,<7.88|>=8,<9.2.13|>=9.3,<9.3.6",
+                "drupal/core": ">=7,<7.91|>=8,<9.3.19|>=9.4,<9.4.3",
                 "drupal/drupal": ">=7,<7.80|>=8,<8.9.16|>=9,<9.1.12|>=9.2,<9.2.4",
                 "dweeves/magmi": "<=0.7.24",
                 "ecodev/newsletter": "<=4",
@@ -3511,6 +3440,7 @@
                 "flarum/sticky": ">=0.1-beta.14,<=0.1-beta.15",
                 "flarum/tags": "<=0.1-beta.13",
                 "fluidtypo3/vhs": "<5.1.1",
+                "fof/byobu": ">=0.3-beta.2,<1.1.7",
                 "fof/upload": "<1.2.3",
                 "fooman/tcpdf": "<6.2.22",
                 "forkcms/forkcms": "<5.11.1",
@@ -3545,6 +3475,7 @@
                 "ibexa/core": ">=4,<4.0.7|>=4.1,<4.1.4",
                 "ibexa/post-install": "<=1.0.4",
                 "icecoder/icecoder": "<=8.1",
+                "idno/known": "<=1.3.1",
                 "illuminate/auth": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.10",
                 "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<=4.1.99999|>=4.2,<=4.2.99999|>=5,<=5.0.99999|>=5.1,<=5.1.99999|>=5.2,<=5.2.99999|>=5.3,<=5.3.99999|>=5.4,<=5.4.99999|>=5.5,<=5.5.49|>=5.6,<=5.6.99999|>=5.7,<=5.7.99999|>=5.8,<=5.8.99999|>=6,<6.18.31|>=7,<7.22.4",
                 "illuminate/database": "<6.20.26|>=7,<7.30.5|>=8,<8.40",
@@ -3552,7 +3483,9 @@
                 "illuminate/view": "<6.20.42|>=7,<7.30.6|>=8,<8.75",
                 "impresscms/impresscms": "<=1.4.3",
                 "in2code/femanager": "<5.5.1|>=6,<6.3.1",
+                "in2code/lux": "<17.6.1|>=18,<24.0.2",
                 "intelliants/subrion": "<=4.2.1",
+                "islandora/islandora": ">=2,<2.4.1",
                 "ivankristianto/phpwhois": "<=4.3",
                 "jackalope/jackalope-doctrine-dbal": "<1.7.4",
                 "james-heinrich/getid3": "<1.9.21",
@@ -3570,11 +3503,11 @@
                 "krayin/laravel-crm": "<1.2.2",
                 "kreait/firebase-php": ">=3.2,<3.8.1",
                 "la-haute-societe/tcpdf": "<6.2.22",
+                "laminas/laminas-diactoros": "<2.11.1",
                 "laminas/laminas-form": "<2.17.1|>=3,<3.0.2|>=3.1,<3.1.1",
                 "laminas/laminas-http": "<2.14.2",
                 "laravel/fortify": "<1.11.1",
                 "laravel/framework": "<6.20.42|>=7,<7.30.6|>=8,<8.75",
-                "laravel/laravel": "<=9.1.8",
                 "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
                 "latte/latte": "<2.10.8",
                 "lavalite/cms": "<=5.8",
@@ -3597,7 +3530,8 @@
                 "matyhtf/framework": "<3.0.6",
                 "mautic/core": "<4.3|= 2.13.1",
                 "mediawiki/core": ">=1.27,<1.27.6|>=1.29,<1.29.3|>=1.30,<1.30.2|>=1.31,<1.31.9|>=1.32,<1.32.6|>=1.32.99,<1.33.3|>=1.33.99,<1.34.3|>=1.34.99,<1.35",
-                "microweber/microweber": "<1.3",
+                "mezzio/mezzio-swoole": "<3.7|>=4,<4.3",
+                "microweber/microweber": "<1.3.1",
                 "miniorange/miniorange-saml": "<1.4.3",
                 "mittwald/typo3_forum": "<1.2.1",
                 "modx/revolution": "<= 2.8.3-pl|<2.8",
@@ -3624,7 +3558,7 @@
                 "october/cms": "= 1.1.1|= 1.0.471|= 1.0.469|>=1.0.319,<1.0.469",
                 "october/october": ">=1.0.319,<1.0.466|>=2.1,<2.1.12",
                 "october/rain": "<1.0.472|>=1.1,<1.1.2",
-                "october/system": "<1.0.475|>=1.1,<1.1.11|>=2,<2.1.27",
+                "october/system": "<1.0.476|>=1.1,<1.1.12|>=2,<2.2.15",
                 "onelogin/php-saml": "<2.10.4",
                 "oneup/uploader-bundle": "<1.9.3|>=2,<2.1.5",
                 "open-web-analytics/open-web-analytics": "<1.7.4",
@@ -3632,8 +3566,10 @@
                 "openid/php-openid": "<2.3",
                 "openmage/magento-lts": "<19.4.15|>=20,<20.0.13",
                 "orchid/platform": ">=9,<9.4.4",
+                "oro/commerce": ">=5,<5.0.4",
                 "oro/crm": ">=1.7,<1.7.4|>=3.1,<4.1.17|>=4.2,<4.2.7",
                 "oro/platform": ">=1.7,<1.7.4|>=3.1,<3.1.29|>=4.1,<4.1.17|>=4.2,<4.2.8",
+                "packbackbooks/lti-1-3-php-library": "<5",
                 "padraic/humbug_get_contents": "<1.1.2",
                 "pagarme/pagarme-php": ">=0,<3",
                 "pagekit/pagekit": "<=1.0.18",
@@ -3659,13 +3595,13 @@
                 "pimcore/data-hub": "<1.2.4",
                 "pimcore/pimcore": "<10.4.4",
                 "pocketmine/bedrock-protocol": "<8.0.2",
-                "pocketmine/pocketmine-mp": ">= 4.0.0-BETA5, < 4.4.2|<4.2.10",
+                "pocketmine/pocketmine-mp": "<4.7.2|>= 4.0.0-BETA5, < 4.4.2",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
                 "prestashop/blockwishlist": ">=2,<2.1.1",
                 "prestashop/contactform": ">1.0.1,<4.3",
                 "prestashop/gamification": "<2.3.2",
-                "prestashop/prestashop": ">=1.7,<=1.7.8.2",
+                "prestashop/prestashop": ">=1.6.0.10,<1.7.8.7",
                 "prestashop/productcomments": ">=4,<4.2.1",
                 "prestashop/ps_emailsubscription": "<2.6.1",
                 "prestashop/ps_facetedsearch": "<3.4.1",
@@ -3692,7 +3628,7 @@
                 "shopware/core": "<=6.4.9",
                 "shopware/platform": "<=6.4.9",
                 "shopware/production": "<=6.3.5.2",
-                "shopware/shopware": "<5.7.12",
+                "shopware/shopware": "<=5.7.13",
                 "shopware/storefront": "<=6.4.8.1",
                 "shopxo/shopxo": "<2.2.6",
                 "showdoc/showdoc": "<2.10.4",
@@ -3717,7 +3653,7 @@
                 "simplito/elliptic-php": "<1.0.6",
                 "slim/slim": "<2.6",
                 "smarty/smarty": "<3.1.45|>=4,<4.1.1",
-                "snipe/snipe-it": "<5.4.4|>= 6.0.0-RC-1, <= 6.0.0-RC-5",
+                "snipe/snipe-it": "<=6.0.2|>= 6.0.0-RC-1, <= 6.0.0-RC-5",
                 "socalnick/scn-social-auth": "<1.15.2",
                 "socialiteproviders/steam": "<1.1",
                 "spipu/html2pdf": "<5.2.4",
@@ -3779,7 +3715,7 @@
                 "thinkcmf/thinkcmf": "<=5.1.7",
                 "tinymce/tinymce": "<5.10",
                 "titon/framework": ">=0,<9.9.99",
-                "topthink/framework": "<6.0.12",
+                "topthink/framework": "<=6.0.12",
                 "topthink/think": "<=6.0.9",
                 "topthink/thinkphp": "<=3.2.3",
                 "tribalsystems/zenario": "<9.2.55826",
@@ -3807,6 +3743,8 @@
                 "webcoast/deferred-image-processing": "<1.0.2",
                 "wikimedia/parsoid": "<0.12.2",
                 "willdurand/js-translation-bundle": "<2.1.1",
+                "wintercms/winter": "<1.0.475|>=1.1,<1.1.9",
+                "woocommerce/woocommerce": "<6.6",
                 "wp-cli/wp-cli": "<2.5",
                 "wp-graphql/wp-graphql": "<0.3.5",
                 "wpanel/wpanel4-cms": "<=4.3.1",
@@ -3886,7 +3824,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-06T08:13:54+00:00"
+            "time": "2022-08-22T17:06:07+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4745,16 +4683,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad"
+                "reference": "fb44e1cc6e557418387ad815780360057e40753e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
-                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb44e1cc6e557418387ad815780360057e40753e",
+                "reference": "fb44e1cc6e557418387ad815780360057e40753e",
                 "shasum": ""
             },
             "require": {
@@ -4766,7 +4704,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -4789,7 +4727,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.0.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.1.0"
             },
             "funding": [
                 {
@@ -4797,7 +4735,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-15T09:54:48+00:00"
+            "time": "2022-08-29T06:55:37+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4854,37 +4792,37 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "7.2.1",
+            "version": "8.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90"
+                "reference": "02f27326be19633a1b6ba76745390bbf9a4be0b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/aff06ae7a84e4534bf6f821dc982a93a5d477c90",
-                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/02f27326be19633a1b6ba76745390bbf9a4be0b6",
+                "reference": "02f27326be19633a1b6ba76745390bbf9a4be0b6",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpdoc-parser": "^1.5.1",
-                "squizlabs/php_codesniffer": "^3.6.2"
+                "phpstan/phpdoc-parser": ">=1.7.0 <1.8.0",
+                "squizlabs/php_codesniffer": "^3.7.1"
             },
             "require-dev": {
-                "phing/phing": "2.17.3",
+                "phing/phing": "2.17.4",
                 "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpstan/phpstan": "1.4.10|1.7.1",
+                "phpstan/phpstan": "1.4.10|1.8.2",
                 "phpstan/phpstan-deprecation-rules": "1.0.0",
                 "phpstan/phpstan-phpunit": "1.0.0|1.1.1",
-                "phpstan/phpstan-strict-rules": "1.2.3",
-                "phpunit/phpunit": "7.5.20|8.5.21|9.5.20"
+                "phpstan/phpstan-strict-rules": "1.3.0",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.21"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.x-dev"
+                    "dev-master": "8.x-dev"
                 }
             },
             "autoload": {
@@ -4899,7 +4837,7 @@
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/7.2.1"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.4.0"
             },
             "funding": [
                 {
@@ -4911,7 +4849,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-25T10:58:12+00:00"
+            "time": "2022-08-09T19:03:45+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -4971,16 +4909,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v5.4.10",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "c4e387b739022fd4b20abd8edb2143c44c5daa14"
+                "reference": "5a0fff46df349f0db3fe242263451fddf5277362"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/c4e387b739022fd4b20abd8edb2143c44c5daa14",
-                "reference": "c4e387b739022fd4b20abd8edb2143c44c5daa14",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/5a0fff46df349f0db3fe242263451fddf5277362",
+                "reference": "5a0fff46df349f0db3fe242263451fddf5277362",
                 "shasum": ""
             },
             "require": {
@@ -5048,7 +4986,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v5.4.10"
+                "source": "https://github.com/symfony/cache/tree/v5.4.11"
             },
             "funding": [
                 {
@@ -5064,7 +5002,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-19T12:03:50+00:00"
+            "time": "2022-07-28T15:25:17+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -5147,16 +5085,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.10",
+            "version": "v5.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "4d671ab4ddac94ee439ea73649c69d9d200b5000"
+                "reference": "c072aa8f724c3af64e2c7a96b796a4863d24dba1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/4d671ab4ddac94ee439ea73649c69d9d200b5000",
-                "reference": "4d671ab4ddac94ee439ea73649c69d9d200b5000",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c072aa8f724c3af64e2c7a96b796a4863d24dba1",
+                "reference": "c072aa8f724c3af64e2c7a96b796a4863d24dba1",
                 "shasum": ""
             },
             "require": {
@@ -5226,7 +5164,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.10"
+                "source": "https://github.com/symfony/console/tree/v5.4.12"
             },
             "funding": [
                 {
@@ -5242,7 +5180,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-26T13:00:04+00:00"
+            "time": "2022-08-17T13:18:05+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -5659,16 +5597,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.10",
+            "version": "v5.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "4432bc7df82a554b3e413a8570ce2fea90e94097"
+                "reference": "2fc515e512d721bf31ea76bd02fe23ada4640058"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/4432bc7df82a554b3e413a8570ce2fea90e94097",
-                "reference": "4432bc7df82a554b3e413a8570ce2fea90e94097",
+                "url": "https://api.github.com/repos/symfony/string/zipball/2fc515e512d721bf31ea76bd02fe23ada4640058",
+                "reference": "2fc515e512d721bf31ea76bd02fe23ada4640058",
                 "shasum": ""
             },
             "require": {
@@ -5725,7 +5663,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.10"
+                "source": "https://github.com/symfony/string/tree/v5.4.12"
             },
             "funding": [
                 {
@@ -5741,7 +5679,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-26T15:57:47+00:00"
+            "time": "2022-08-12T17:03:11+00:00"
         },
         {
             "name": "symfony/var-exporter",
@@ -5868,16 +5806,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.24.0",
+            "version": "4.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "06dd975cb55d36af80f242561738f16c5f58264f"
+                "reference": "6998fabb2bf528b65777bf9941920888d23c03ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/06dd975cb55d36af80f242561738f16c5f58264f",
-                "reference": "06dd975cb55d36af80f242561738f16c5f58264f",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/6998fabb2bf528b65777bf9941920888d23c03ac",
+                "reference": "6998fabb2bf528b65777bf9941920888d23c03ac",
                 "shasum": ""
             },
             "require": {
@@ -5969,9 +5907,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.24.0"
+                "source": "https://github.com/vimeo/psalm/tree/4.26.0"
             },
-            "time": "2022-06-26T11:47:54+00:00"
+            "time": "2022-07-31T13:10:26+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Api.php
+++ b/src/Api.php
@@ -127,19 +127,19 @@ final class Api implements ApiClient
             $apiBaseUri,
             $httpClient ?? self::psrFactory(
                 ClientInterface::class,
-                'An HTTP client cannot be determined.'
+                'An HTTP client cannot be determined.',
             ),
             (string) $accessToken === '' ? null : $accessToken,
             $requestFactory ?? self::psrFactory(
                 RequestFactoryInterface::class,
-                'A request factory cannot be determined'
+                'A request factory cannot be determined',
             ),
             $uriFactory ?? self::psrFactory(
                 UriFactoryInterface::class,
-                'A URI factory cannot be determined'
+                'A URI factory cannot be determined',
             ),
             $resultSetFactory ?? new StandardResultSetFactory(),
-            $cache
+            $cache,
         );
     }
 
@@ -168,14 +168,14 @@ final class Api implements ApiClient
                 default:
                     throw new InvalidArgument(sprintf(
                         'Invalid class-string: "%s"',
-                        $type
+                        $type,
                     ));
             }
         } catch (DiscoveryError $error) {
             throw new RuntimeError(
                 $message,
                 (int) $error->getCode(),
-                $error
+                $error,
             );
         }
     }
@@ -220,7 +220,7 @@ final class Api implements ApiClient
             throw new RuntimeError(
                 sprintf('The caching library in use threw an exception for the cache key: %s', $cacheKey),
                 500,
-                $e
+                $e,
             );
         }
 
@@ -312,7 +312,7 @@ final class Api implements ApiClient
     public function query(Query $query): ResultSet
     {
         return $this->resultSetFactory->withJsonObject($this->jsonResponse(
-            $this->uriFactory->createUri($query->toUrl())
+            $this->uriFactory->createUri($query->toUrl()),
         ));
     }
 
@@ -392,7 +392,7 @@ final class Api implements ApiClient
                 'preview',
                 $cookiePayload,
                 'Preview',
-                false
+                false,
             );
         }
 
@@ -469,7 +469,7 @@ final class Api implements ApiClient
         }
 
         return $this->resultSetFactory->withJsonObject(
-            $this->jsonResponse($uri)
+            $this->jsonResponse($uri),
         );
     }
 
@@ -486,7 +486,7 @@ final class Api implements ApiClient
         }
 
         return $this->resultSetFactory->withJsonObject(
-            $this->jsonResponse($uri)
+            $this->jsonResponse($uri),
         );
     }
 

--- a/src/Document/Fragment/BaseCollection.php
+++ b/src/Document/Fragment/BaseCollection.php
@@ -112,7 +112,7 @@ abstract class BaseCollection implements FragmentCollection
         $result = array_filter($this->fragments, $p, ARRAY_FILTER_USE_BOTH);
 
         return new static(
-            $this->isHash($result) ? $result : array_values($result)
+            $this->isHash($result) ? $result : array_values($result),
         );
     }
 

--- a/src/Document/Fragment/DateFragment.php
+++ b/src/Document/Fragment/DateFragment.php
@@ -9,9 +9,7 @@ use DateTimeZone;
 use Prismic\Document\Fragment;
 use Prismic\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class DateFragment extends DateTimeImmutable implements Fragment
 {
     /**

--- a/src/Document/Fragment/DocumentLink.php
+++ b/src/Document/Fragment/DocumentLink.php
@@ -68,7 +68,7 @@ final class DocumentLink implements Fragment, Link
             $document->type(),
             $document->lang(),
             false,
-            $document->tags()
+            $document->tags(),
         );
     }
 

--- a/src/Document/Fragment/Embed.php
+++ b/src/Document/Fragment/Embed.php
@@ -67,14 +67,10 @@ final class Embed implements Fragment
         }
     }
 
-    /**
-     * @param scalar|null $value
-     */
+    /** @param scalar|null $value */
     private function setAttribute(string $name, $value): void
     {
-        /**
-         * @psalm-suppress DocblockTypeContradiction
-         */
+        /** @psalm-suppress DocblockTypeContradiction */
         if ($value !== null && ! is_scalar($value)) {
             throw InvalidArgument::scalarExpected($value);
         }

--- a/src/Document/Fragment/Factory.php
+++ b/src/Document/Fragment/Factory.php
@@ -92,7 +92,7 @@ final class Factory
         if (property_exists($data, 'latitude')) {
             return GeoPoint::new(
                 self::assertObjectPropertyIsFloaty($data, 'latitude'),
-                self::assertObjectPropertyIsFloaty($data, 'longitude')
+                self::assertObjectPropertyIsFloaty($data, 'longitude'),
             );
         }
 
@@ -165,7 +165,7 @@ final class Factory
             self::optionalStringProperty($data, 'alt'),
             self::optionalStringProperty($data, 'copyright'),
             $views,
-            $linkTo
+            $linkTo,
         );
     }
 
@@ -176,7 +176,7 @@ final class Factory
         if ($type === 'Web') {
             return WebLink::new(
                 self::assertObjectPropertyIsString($data, 'url'),
-                self::optionalStringProperty($data, 'target')
+                self::optionalStringProperty($data, 'target'),
             );
         }
 
@@ -212,7 +212,7 @@ final class Factory
                 self::assertObjectPropertyIsString($data, 'type'),
                 $lang,
                 $isBroken,
-                self::assertObjectPropertyAllString($data, 'tags')
+                self::assertObjectPropertyAllString($data, 'tags'),
             );
         }
 
@@ -235,7 +235,7 @@ final class Factory
             self::optionalStringProperty($data, 'html'),
             self::optionalIntegerPropertyOrNull($data, 'width'),
             self::optionalIntegerPropertyOrNull($data, 'height'),
-            $scalars
+            $scalars,
         );
     }
 
@@ -254,7 +254,7 @@ final class Factory
             self::assertObjectPropertyIsString($data, 'slice_type'),
             self::optionalStringProperty($data, 'slice_label'),
             $primary,
-            $items
+            $items,
         );
     }
 
@@ -266,7 +266,7 @@ final class Factory
             array_map(static function (object $span): Span {
                 return self::spanFactory($span);
             }, self::assertObjectPropertyIsArray($data, 'spans')),
-            self::optionalStringProperty($data, 'label')
+            self::optionalStringProperty($data, 'label'),
         );
     }
 
@@ -286,7 +286,7 @@ final class Factory
             self::assertObjectPropertyIsInteger($data, 'start'),
             self::assertObjectPropertyIsInteger($data, 'end'),
             $label,
-            $link
+            $link,
         );
     }
 

--- a/src/Document/Fragment/Image.php
+++ b/src/Document/Fragment/Image.php
@@ -15,9 +15,7 @@ use Traversable;
 use function array_keys;
 use function count;
 
-/**
- * @template-implements IteratorAggregate<string, Image>
- */
+/** @template-implements IteratorAggregate<string, Image> */
 final class Image implements Fragment, IteratorAggregate, Countable
 {
     /** @var string */
@@ -135,9 +133,7 @@ final class Image implements Fragment, IteratorAggregate, Countable
         return $this->link;
     }
 
-    /**
-     * @return Traversable<string, self>
-     */
+    /** @return Traversable<string, self> */
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->views);

--- a/src/Document/Fragment/TextElement.php
+++ b/src/Document/Fragment/TextElement.php
@@ -57,7 +57,7 @@ final class TextElement implements Fragment, Stringable
             $type,
             $text ?? '',
             $spans,
-            $label
+            $label,
         );
     }
 

--- a/src/Exception/AuthenticationError.php
+++ b/src/Exception/AuthenticationError.php
@@ -22,7 +22,7 @@ final class AuthenticationError extends RequestFailure
             $response->getStatusCode(),
             $response->getReasonPhrase(),
             $request->getUri()->getHost(),
-            $url
+            $url,
         ), $response->getStatusCode());
         $error->request = $request;
         $error->response = $response;

--- a/src/Exception/ImageViewNotFound.php
+++ b/src/Exception/ImageViewNotFound.php
@@ -16,7 +16,7 @@ final class ImageViewNotFound extends InvalidArgument
         return new self(sprintf(
             'The image view "%s" does not exist. Known view names are: %s',
             $name,
-            implode(', ', $image->knownViews())
+            implode(', ', $image->knownViews()),
         ));
     }
 }

--- a/src/Exception/InvalidArgument.php
+++ b/src/Exception/InvalidArgument.php
@@ -20,7 +20,7 @@ class InvalidArgument extends InvalidArgumentException implements PrismicError
     {
         return new self(sprintf(
             'A scalar argument was expected but %s was received',
-            is_object($received) ? get_class($received) : gettype($received)
+            is_object($received) ? get_class($received) : gettype($received),
         ));
     }
 
@@ -29,7 +29,7 @@ class InvalidArgument extends InvalidArgumentException implements PrismicError
     {
         return new self(sprintf(
             'Either a float or an integer was expected but %s was received',
-            is_object($received) ? get_class($received) : gettype($received)
+            is_object($received) ? get_class($received) : gettype($received),
         ));
     }
 
@@ -37,7 +37,7 @@ class InvalidArgument extends InvalidArgumentException implements PrismicError
     {
         return new self(sprintf(
             'Expected a string that looks like a hex colour with a # prefix but received "%s"',
-            $value
+            $value,
         ));
     }
 
@@ -46,7 +46,7 @@ class InvalidArgument extends InvalidArgumentException implements PrismicError
         return new self(sprintf(
             'Expected a date value in the format %s but received "%s"',
             $expectedFormat,
-            $value
+            $value,
         ));
     }
 
@@ -55,7 +55,7 @@ class InvalidArgument extends InvalidArgumentException implements PrismicError
         return new self(sprintf(
             'The link type "%s" is not a known type of link. Found in the object: %s',
             $type,
-            Json::encode($payload)
+            Json::encode($payload),
         ));
     }
 
@@ -65,7 +65,7 @@ class InvalidArgument extends InvalidArgumentException implements PrismicError
         return new self(sprintf(
             'The form field "%s" expects a string value but received %s',
             $field->name(),
-            is_object($invalidValue) ? get_class($invalidValue) : gettype($invalidValue)
+            is_object($invalidValue) ? get_class($invalidValue) : gettype($invalidValue),
         ));
     }
 
@@ -75,7 +75,7 @@ class InvalidArgument extends InvalidArgumentException implements PrismicError
         return new self(sprintf(
             'The form field "%s" expects an integer value but received %s',
             $field->name(),
-            is_object($invalidValue) ? get_class($invalidValue) : gettype($invalidValue)
+            is_object($invalidValue) ? get_class($invalidValue) : gettype($invalidValue),
         ));
     }
 }

--- a/src/Exception/InvalidPreviewToken.php
+++ b/src/Exception/InvalidPreviewToken.php
@@ -16,7 +16,7 @@ final class InvalidPreviewToken extends InvalidArgument
         return new self(sprintf(
             'The preview url has been rejected because its host name "%s" does not match the api host "%s"',
             $previewUri->getHost(),
-            $apiUri->getHost()
+            $apiUri->getHost(),
         ));
     }
 

--- a/src/Exception/JsonError.php
+++ b/src/Exception/JsonError.php
@@ -18,10 +18,10 @@ final class JsonError extends JsonException implements PrismicError
         $error = new self(
             sprintf(
                 'Failed to decode JSON payload: %s',
-                $exception->getMessage()
+                $exception->getMessage(),
             ),
             (int) $exception->getCode(),
-            $exception
+            $exception,
         );
 
         $error->payload = $payload;
@@ -34,10 +34,10 @@ final class JsonError extends JsonException implements PrismicError
         return new self(
             sprintf(
                 'Failed to encode the given data to a JSON string: %s',
-                $exception->getMessage()
+                $exception->getMessage(),
             ),
             (int) $exception->getCode(),
-            $exception
+            $exception,
         );
     }
 
@@ -45,7 +45,7 @@ final class JsonError extends JsonException implements PrismicError
     {
         return new self(sprintf(
             'The given payload cannot be unserialized as an object: %s',
-            $payload
+            $payload,
         ));
     }
 
@@ -53,7 +53,7 @@ final class JsonError extends JsonException implements PrismicError
     {
         return new self(sprintf(
             'The given payload cannot be unserialized as an array: %s',
-            $payload
+            $payload,
         ));
     }
 

--- a/src/Exception/PreviewTokenExpired.php
+++ b/src/Exception/PreviewTokenExpired.php
@@ -47,7 +47,7 @@ final class PreviewTokenExpired extends RequestFailure
     {
         $error = new self(sprintf(
             'Error %d. The preview token provided has expired',
-            $response->getStatusCode()
+            $response->getStatusCode(),
         ), $response->getStatusCode());
         $error->request = $request;
         $error->response = $response;

--- a/src/Exception/RequestFailure.php
+++ b/src/Exception/RequestFailure.php
@@ -24,7 +24,7 @@ class RequestFailure extends RuntimeException implements PrismicError
         return new self(
             $exception->getMessage(),
             (int) $exception->getCode(),
-            $exception
+            $exception,
         );
     }
 
@@ -33,7 +33,7 @@ class RequestFailure extends RuntimeException implements PrismicError
         $error = new self(sprintf(
             'The request to the URL "%s" resulted in a %d redirect. I don’t know what to do with that.',
             (string) $request->getUri(),
-            $response->getStatusCode()
+            $response->getStatusCode(),
         ), $response->getStatusCode());
         $error->request = $request;
         $error->response = $response;
@@ -56,7 +56,7 @@ class RequestFailure extends RuntimeException implements PrismicError
             'Error %d. The request to the URL "%s" was rejected by the api. The error response body was "%s"',
             $status,
             (string) $request->getUri(),
-            (string) $response->getBody()
+            (string) $response->getBody(),
         ), $response->getStatusCode());
         $error->request = $request;
         $error->response = $response;
@@ -69,7 +69,7 @@ class RequestFailure extends RuntimeException implements PrismicError
         $error = new self(sprintf(
             'The request to the URL "%s" resulted in a server error. The error response body was "%s"',
             (string) $request->getUri(),
-            (string) $response->getBody()
+            (string) $response->getBody(),
         ), $response->getStatusCode());
         $error->request = $request;
         $error->response = $response;

--- a/src/Exception/UnexpectedValue.php
+++ b/src/Exception/UnexpectedValue.php
@@ -17,7 +17,7 @@ final class UnexpectedValue extends UnexpectedValueException implements PrismicE
         $message = sprintf(
             'Expected an object to contain the property "%s" but it was not present: Received %s',
             $property,
-            Json::encode($object)
+            Json::encode($object),
         );
 
         return new self($message);
@@ -30,7 +30,7 @@ final class UnexpectedValue extends UnexpectedValueException implements PrismicE
             $property,
             $expectedType,
             gettype($object->{$property}),
-            Json::encode($object)
+            Json::encode($object),
         ));
     }
 

--- a/src/Exception/UnknownBookmark.php
+++ b/src/Exception/UnknownBookmark.php
@@ -12,7 +12,7 @@ final class UnknownBookmark extends InvalidArgument
     {
         return new self(sprintf(
             'There is no bookmark available with the name %s',
-            $name
+            $name,
         ));
     }
 }

--- a/src/Exception/UnknownForm.php
+++ b/src/Exception/UnknownForm.php
@@ -12,7 +12,7 @@ final class UnknownForm extends InvalidArgument
     {
         return new self(sprintf(
             'There is no form available with the name %s',
-            $name
+            $name,
         ));
     }
 }

--- a/src/Exception/UnknownFormField.php
+++ b/src/Exception/UnknownFormField.php
@@ -15,7 +15,7 @@ final class UnknownFormField extends InvalidArgument
         return new self(sprintf(
             'There is no field with the name %s in the form %s',
             $key,
-            $form->id()
+            $form->id(),
         ));
     }
 }

--- a/src/Json.php
+++ b/src/Json.php
@@ -16,9 +16,7 @@ use const JSON_THROW_ON_ERROR;
 
 final class Json
 {
-    /**
-     * @throws JsonError If decoding the payload fails for any reason.
-     */
+    /** @throws JsonError If decoding the payload fails for any reason. */
     public static function decodeObject(string $jsonString): object
     {
         try {

--- a/src/Predicate.php
+++ b/src/Predicate.php
@@ -14,9 +14,7 @@ use function is_numeric;
 
 use const JSON_UNESCAPED_SLASHES;
 
-/**
- * @psalm-type ArgType = list<scalar|list<scalar>>
- */
+/** @psalm-type ArgType = list<scalar|list<scalar>> */
 final class Predicate implements Stringable
 {
     /** @var string  */
@@ -45,7 +43,7 @@ final class Predicate implements Stringable
         return new self(
             $data['name'],
             $data['fragment'],
-            $data['args']
+            $data['args'],
         );
     }
 
@@ -72,9 +70,7 @@ final class Predicate implements Stringable
         return $query;
     }
 
-    /**
-     * @param mixed $value
-     */
+    /** @param mixed $value */
     private function serializeField($value): string
     {
         if (is_array($value)) {
@@ -84,9 +80,7 @@ final class Predicate implements Stringable
         return Json::encode($value, JSON_UNESCAPED_SLASHES);
     }
 
-    /**
-     * @param scalar|list<scalar> $value
-     */
+    /** @param scalar|list<scalar> $value */
     public static function at(string $fragment, $value): self
     {
         return new self('at', $fragment, [$value]);
@@ -97,17 +91,13 @@ final class Predicate implements Stringable
         return self::at('document.tags', [$tag]);
     }
 
-    /**
-     * @param scalar|list<scalar> $value
-     */
+    /** @param scalar|list<scalar> $value */
     public static function not(string $fragment, $value): self
     {
         return new self('not', $fragment, [$value]);
     }
 
-    /**
-     * @param list<scalar> $values
-     */
+    /** @param list<scalar> $values */
     public static function any(string $fragment, array $values): self
     {
         return new self('any', $fragment, [$values]);
@@ -149,28 +139,24 @@ final class Predicate implements Stringable
         return new self('similar', $documentId, [$documentOccurrenceThreshold]);
     }
 
-    /**
-     * @param int|float|string $lowerBound A number or numeric string
-     */
+    /** @param int|float|string $lowerBound A number or numeric string */
     public static function lt(string $fragment, $lowerBound): self
     {
         if (! is_numeric($lowerBound)) {
             throw new InvalidArgument(
-                'Predicates::lt() expects a number as it’s second argument'
+                'Predicates::lt() expects a number as it’s second argument',
             );
         }
 
         return new self('number.lt', $fragment, [$lowerBound]);
     }
 
-    /**
-     * @param int|float|string $upperBound A number or numeric string
-     */
+    /** @param int|float|string $upperBound A number or numeric string */
     public static function gt(string $fragment, $upperBound): self
     {
         if (! is_numeric($upperBound)) {
             throw new InvalidArgument(
-                'Predicates::gt() expects a number as it’s second argument'
+                'Predicates::gt() expects a number as it’s second argument',
             );
         }
 
@@ -185,16 +171,14 @@ final class Predicate implements Stringable
     {
         if (! is_numeric($upperBound) || ! is_numeric($lowerBound)) {
             throw new InvalidArgument(
-                'Predicates::inRange() expects numbers for it’s second and third arguments'
+                'Predicates::inRange() expects numbers for it’s second and third arguments',
             );
         }
 
         return new self('number.inRange', $fragment, [$lowerBound, $upperBound]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $before
-     */
+    /** @param DateTimeInterface|int|string $before */
     public static function dateBefore(string $fragment, $before): self
     {
         if ($before instanceof DateTimeInterface) {
@@ -204,9 +188,7 @@ final class Predicate implements Stringable
         return new self('date.before', $fragment, [$before]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $after
-     */
+    /** @param DateTimeInterface|int|string $after */
     public static function dateAfter(string $fragment, $after): self
     {
         if ($after instanceof DateTimeInterface) {
@@ -233,9 +215,7 @@ final class Predicate implements Stringable
         return new self('date.between', $fragment, [$before, $after]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $day
-     */
+    /** @param DateTimeInterface|int|string $day */
     public static function dayOfMonth(string $fragment, $day): self
     {
         if ($day instanceof DateTimeInterface) {
@@ -245,9 +225,7 @@ final class Predicate implements Stringable
         return new self('date.day-of-month', $fragment, [$day]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $day
-     */
+    /** @param DateTimeInterface|int|string $day */
     public static function dayOfMonthBefore(string $fragment, $day): self
     {
         if ($day instanceof DateTimeInterface) {
@@ -257,9 +235,7 @@ final class Predicate implements Stringable
         return new self('date.day-of-month-before', $fragment, [$day]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $day
-     */
+    /** @param DateTimeInterface|int|string $day */
     public static function dayOfMonthAfter(string $fragment, $day): self
     {
         if ($day instanceof DateTimeInterface) {
@@ -269,9 +245,7 @@ final class Predicate implements Stringable
         return new self('date.day-of-month-after', $fragment, [$day]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $day
-     */
+    /** @param DateTimeInterface|int|string $day */
     public static function dayOfWeek(string $fragment, $day): self
     {
         if ($day instanceof DateTimeInterface) {
@@ -281,9 +255,7 @@ final class Predicate implements Stringable
         return new self('date.day-of-week', $fragment, [$day]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $day
-     */
+    /** @param DateTimeInterface|int|string $day */
     public static function dayOfWeekBefore(string $fragment, $day): self
     {
         if ($day instanceof DateTimeInterface) {
@@ -293,9 +265,7 @@ final class Predicate implements Stringable
         return new self('date.day-of-week-before', $fragment, [$day]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $day
-     */
+    /** @param DateTimeInterface|int|string $day */
     public static function dayOfWeekAfter(string $fragment, $day): self
     {
         if ($day instanceof DateTimeInterface) {
@@ -305,9 +275,7 @@ final class Predicate implements Stringable
         return new self('date.day-of-week-after', $fragment, [$day]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $month
-     */
+    /** @param DateTimeInterface|int|string $month */
     public static function month(string $fragment, $month): self
     {
         if ($month instanceof DateTimeInterface) {
@@ -317,9 +285,7 @@ final class Predicate implements Stringable
         return new self('date.month', $fragment, [$month]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $month
-     */
+    /** @param DateTimeInterface|int|string $month */
     public static function monthBefore(string $fragment, $month): self
     {
         if ($month instanceof DateTimeInterface) {
@@ -329,9 +295,7 @@ final class Predicate implements Stringable
         return new self('date.month-before', $fragment, [$month]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $month
-     */
+    /** @param DateTimeInterface|int|string $month */
     public static function monthAfter(string $fragment, $month): self
     {
         if ($month instanceof DateTimeInterface) {
@@ -341,9 +305,7 @@ final class Predicate implements Stringable
         return new self('date.month-after', $fragment, [$month]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $year
-     */
+    /** @param DateTimeInterface|int|string $year */
     public static function year(string $fragment, $year): self
     {
         if ($year instanceof DateTimeInterface) {
@@ -353,9 +315,7 @@ final class Predicate implements Stringable
         return new self('date.year', $fragment, [$year]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $hour
-     */
+    /** @param DateTimeInterface|int|string $hour */
     public static function hour(string $fragment, $hour): self
     {
         if ($hour instanceof DateTimeInterface) {
@@ -365,9 +325,7 @@ final class Predicate implements Stringable
         return new self('date.hour', $fragment, [$hour]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $hour
-     */
+    /** @param DateTimeInterface|int|string $hour */
     public static function hourBefore(string $fragment, $hour): self
     {
         if ($hour instanceof DateTimeInterface) {
@@ -377,9 +335,7 @@ final class Predicate implements Stringable
         return new self('date.hour-before', $fragment, [$hour]);
     }
 
-    /**
-     * @param DateTimeInterface|int|string $hour
-     */
+    /** @param DateTimeInterface|int|string $hour */
     public static function hourAfter(string $fragment, $hour): self
     {
         if ($hour instanceof DateTimeInterface) {
@@ -389,9 +345,7 @@ final class Predicate implements Stringable
         return new self('date.hour-after', $fragment, [$hour]);
     }
 
-    /**
-     * @param float $radius In Kilometers
-     */
+    /** @param float $radius In Kilometers */
     public static function near(string $fragment, float $latitude, float $longitude, float $radius): self
     {
         return new self('geopoint.near', $fragment, [$latitude, $longitude, $radius]);

--- a/src/ResultSet/StandardResultSet.php
+++ b/src/ResultSet/StandardResultSet.php
@@ -89,7 +89,7 @@ final class StandardResultSet implements ResultSet
             self::assertObjectPropertyIsInteger($data, 'total_pages'),
             self::optionalStringProperty($data, 'next_page'),
             self::optionalStringProperty($data, 'prev_page'),
-            $results
+            $results,
         );
     }
 
@@ -121,7 +121,7 @@ final class StandardResultSet implements ResultSet
             max($this->pageCount - 1, 1),
             $with->nextPage(),
             $this->prevPage,
-            $results
+            $results,
         );
     }
 }

--- a/src/ResultSet/TypicalResultSetBehaviour.php
+++ b/src/ResultSet/TypicalResultSetBehaviour.php
@@ -11,9 +11,7 @@ use Traversable;
 use function count;
 use function reset;
 
-/**
- * @template T of Document
- */
+/** @template T of Document */
 trait TypicalResultSetBehaviour
 {
     /** @var list<T> */

--- a/src/Serializer/HtmlSerializer.php
+++ b/src/Serializer/HtmlSerializer.php
@@ -105,13 +105,13 @@ class HtmlSerializer
             case BooleanFragment::class:
                 return sprintf(
                     '<kbd class="boolean">%s</kbd>',
-                    $fragment() ? 'true' : 'false'
+                    $fragment() ? 'true' : 'false',
                 );
 
             case Number::class:
                 return sprintf(
                     '<kbd class="number">%d</kbd>',
-                    (string) $fragment
+                    (string) $fragment,
                 );
 
             case EmptyFragment::class:
@@ -123,21 +123,21 @@ class HtmlSerializer
             case StringFragment::class:
                 return sprintf(
                     '<kbd>%s</kbd>',
-                    $this->escaper->escapeHtml((string) $fragment)
+                    $this->escaper->escapeHtml((string) $fragment),
                 );
 
             case GeoPoint::class:
                 return sprintf(
                     '<span class="geopoint" data-latitude="%1$s" data-longitude="%2$s">%1$s, %2$s</span>',
                     $fragment->latitude(),
-                    $fragment->latitude()
+                    $fragment->latitude(),
                 );
 
             case Color::class:
                 return sprintf(
                     '<kbd class="color" style="background-color: %1$s; color: %2$s">%1$s</kbd>',
                     (string) $fragment,
-                    (string) $fragment->invert()
+                    (string) $fragment->invert(),
                 );
 
             case Image::class:
@@ -161,7 +161,7 @@ class HtmlSerializer
 
         throw new UnexpectedValue(sprintf(
             'I don’t know how to serialize %s instances',
-            get_class($fragment)
+            get_class($fragment),
         ));
     }
 
@@ -172,7 +172,7 @@ class HtmlSerializer
         return sprintf(
             '<time datetime="%s">%s</time>',
             $date->format($fragment->isDay() ? 'Y-m-d' : DateTimeInterface::ATOM),
-            $date->format($fragment->isDay() ? $this->dateFormat : $this->dateTimeFormat)
+            $date->format($fragment->isDay() ? $this->dateFormat : $this->dateTimeFormat),
         );
     }
 
@@ -190,7 +190,7 @@ class HtmlSerializer
         return sprintf(
             '<%1$s>%2$s</%1$s>',
             $htmlList instanceof OrderedList ? 'ol' : 'ul',
-            implode('', $items)
+            implode('', $items),
         );
     }
 
@@ -229,7 +229,7 @@ class HtmlSerializer
         return sprintf(
             '%s%s</a>',
             $openTag,
-            $wraps ?: (string) $link
+            $wraps ?: (string) $link,
         );
     }
 
@@ -266,7 +266,7 @@ class HtmlSerializer
             '<div%s>%s%s</div>',
             $this->htmlAttributes($attributes),
             $primary,
-            $items
+            $items,
         );
     }
 
@@ -284,7 +284,7 @@ class HtmlSerializer
             '<%1$s%2$s>%3$s</%1$s>',
             $this->tagMap[$fragment->type()],
             $attributes,
-            $this->insertSpans($fragment, $fragment->text(), $fragment->spans())
+            $this->insertSpans($fragment, $fragment->text(), $fragment->spans()),
         );
     }
 
@@ -367,7 +367,7 @@ class HtmlSerializer
         return sprintf(
             '<div%1$s>%2$s</div>',
             $attributes,
-            (string) $embed->html()
+            (string) $embed->html(),
         );
     }
 }

--- a/src/Value/ApiData.php
+++ b/src/Value/ApiData.php
@@ -12,9 +12,7 @@ use function array_keys;
 use function array_map;
 use function get_object_vars;
 
-/**
- * @psalm-suppress DeprecatedClass, DeprecatedMethod
- */
+/** @psalm-suppress DeprecatedClass, DeprecatedMethod */
 final class ApiData
 {
     use DataAssertionBehaviour;
@@ -80,7 +78,7 @@ final class ApiData
             $tags,
             array_map(static function (string $name, string $id): Bookmark {
                 return Bookmark::new($name, $id);
-            }, array_keys($bookmarks), $bookmarks)
+            }, array_keys($bookmarks), $bookmarks),
         );
     }
 
@@ -100,9 +98,7 @@ final class ApiData
         return $this->getForm($name) instanceof FormSpec;
     }
 
-    /**
-     * @throws UnknownForm if $name does not correspond to a known form.
-     */
+    /** @throws UnknownForm if $name does not correspond to a known form. */
     public function form(string $name): FormSpec
     {
         $form = $this->getForm($name);
@@ -136,17 +132,13 @@ final class ApiData
         return $this->tags;
     }
 
-    /**
-     * @deprecated Bookmarks are deprecated - Removal in v2.0.
-     */
+    /** @deprecated Bookmarks are deprecated - Removal in v2.0. */
     public function isBookmarked(string $id): bool
     {
         return $this->bookmarkFromDocumentId($id) instanceof Bookmark;
     }
 
-    /**
-     * @deprecated Bookmarks are deprecated - Removal in v2.0.
-     */
+    /** @deprecated Bookmarks are deprecated - Removal in v2.0. */
     public function bookmarkFromDocumentId(string $id): ?Bookmark
     {
         foreach ($this->bookmarks as $bookmark) {

--- a/src/Value/DataAssertionBehaviour.php
+++ b/src/Value/DataAssertionBehaviour.php
@@ -169,7 +169,7 @@ trait DataAssertionBehaviour
         $date = DateTimeImmutable::createFromFormat(
             DateTimeInterface::ATOM,
             self::assertObjectPropertyIsString($object, $property),
-            new DateTimeZone('UTC')
+            new DateTimeZone('UTC'),
         );
         assert($date instanceof DateTimeImmutable);
 

--- a/src/Value/DocumentData.php
+++ b/src/Value/DocumentData.php
@@ -98,7 +98,7 @@ final class DocumentData implements Document
             self::assertObjectPropertyIsUtcDateTime($data, 'last_publication_date'),
             self::assertObjectPropertyAllString($data, 'tags'),
             $translations,
-            $body
+            $body,
         );
     }
 

--- a/src/Value/FormField.php
+++ b/src/Value/FormField.php
@@ -44,7 +44,7 @@ final class FormField
             $name,
             self::assertObjectPropertyIsString($value, 'type'),
             self::assertObjectPropertyIsBoolean($value, 'multiple'),
-            self::optionalStringProperty($value, 'default')
+            self::optionalStringProperty($value, 'default'),
         );
     }
 

--- a/src/Value/FormSpec.php
+++ b/src/Value/FormSpec.php
@@ -63,7 +63,7 @@ final class FormSpec implements IteratorAggregate
             self::assertObjectPropertyIsString($object, 'action'),
             ...array_map(static function (string $fieldName, object $spec): FormField {
                 return FormField::factory($fieldName, $spec);
-            }, array_keys($fields), $fields)
+            }, array_keys($fields), $fields),
         );
     }
 

--- a/test/Smoke/ApiTest.php
+++ b/test/Smoke/ApiTest.php
@@ -14,9 +14,7 @@ use function assert;
 use function count;
 use function sprintf;
 
-/**
- * @psalm-suppress DeprecatedMethod
- */
+/** @psalm-suppress DeprecatedMethod */
 class ApiTest extends TestCase
 {
     /**
@@ -30,7 +28,7 @@ class ApiTest extends TestCase
             assert($api instanceof Api);
             $response = $api->query(
                 $api->createQuery()
-                    ->resultsPerPage(10)
+                    ->resultsPerPage(10),
             );
             foreach ($response as $document) {
                 yield sprintf('%s: %s', $api->host(), $document->id()) => [$api, $document->id()];
@@ -59,7 +57,7 @@ class ApiTest extends TestCase
                 $response = $api->query(
                     $api->createQuery()
                         ->resultsPerPage(1)
-                        ->query(Predicate::has(sprintf('my.%s.uid', $type->id())))
+                        ->query(Predicate::has(sprintf('my.%s.uid', $type->id()))),
                 );
 
                 foreach ($response as $document) {

--- a/test/Smoke/PredicateUseCaseTest.php
+++ b/test/Smoke/PredicateUseCaseTest.php
@@ -45,7 +45,7 @@ class PredicateUseCaseTest extends TestCase
                 $this->fail(sprintf(
                     'The full text search for "%s" failed with the error message: %s',
                     $term,
-                    $error->getMessage()
+                    $error->getMessage(),
                 ));
             }
         }

--- a/test/Smoke/TestCase.php
+++ b/test/Smoke/TestCase.php
@@ -43,7 +43,7 @@ class TestCase extends PHPUnitTestCase
         if (! $this->httpClient) {
             $this->httpClient = new PluginClient(
                 HttpClientDiscovery::find(),
-                [new CachePlugin($this->psrCachePool(), Psr17FactoryDiscovery::findStreamFactory())]
+                [new CachePlugin($this->psrCachePool(), Psr17FactoryDiscovery::findStreamFactory())],
             );
         }
 
@@ -66,7 +66,6 @@ class TestCase extends PHPUnitTestCase
             return $endpoints;
         }
 
-        /** @psalm-suppress MissingFile $content */
         $content = require $configPath;
         if (! is_array($content)) {
             return $endpoints;

--- a/test/Smoke/TestCase.php
+++ b/test/Smoke/TestCase.php
@@ -66,6 +66,7 @@ class TestCase extends PHPUnitTestCase
             return $endpoints;
         }
 
+        /** @psalm-suppress MissingFile */
         $content = require $configPath;
         if (! is_array($content)) {
             return $endpoints;

--- a/test/Unit/ApiTest.php
+++ b/test/Unit/ApiTest.php
@@ -49,7 +49,7 @@ class ApiTest extends TestCase
     /** @var JsonResponse */
     private $response;
 
-    private const DOCUMENT_PREVIEW_PAYLOAD = <<<JSON
+    private const DOCUMENT_PREVIEW_PAYLOAD = <<<'JSON'
         {
           "label": "Example Label",
           "ref": "preview-ref",
@@ -58,7 +58,7 @@ class ApiTest extends TestCase
         }
         JSON;
 
-    private const NO_DOCUMENT_PREVIEW_PAYLOAD = <<<JSON
+    private const NO_DOCUMENT_PREVIEW_PAYLOAD = <<<'JSON'
         {
           "label": "No Document",
           "ref": "preview-ref",
@@ -119,7 +119,7 @@ class ApiTest extends TestCase
         $this->expectException(RequestFailure::class);
         $this->expectExceptionMessage(
             'Error 400. The request to the URL "https://example.com" was rejected '
-            . 'by the api. The error response body was "Nice Body"'
+            . 'by the api. The error response body was "Nice Body"',
         );
         $this->expectExceptionCode(400);
         $api->data();
@@ -151,7 +151,7 @@ class ApiTest extends TestCase
         $this->expectException(RequestFailure::class);
         $this->expectExceptionMessage(
             'The request to the URL "https://example.com" resulted in a server error. '
-            . 'The error response body was "Whoops"'
+            . 'The error response body was "Whoops"',
         );
         $this->expectExceptionCode(500);
         $api->data();
@@ -295,7 +295,7 @@ class ApiTest extends TestCase
         $api = Api::get('https://example.com', null, $this->httpClient);
         $this->httpClient->setDefaultResponse(new JsonResponse(Json::decodeObject(self::NO_DOCUMENT_PREVIEW_PAYLOAD)));
         self::assertNull(
-            $api->previewSession('https://example.com/previews/stuff:morestuff')
+            $api->previewSession('https://example.com/previews/stuff:morestuff'),
         );
     }
 
@@ -321,7 +321,7 @@ class ApiTest extends TestCase
                 self::assertStringContainsString('target-document-id', $url->getQuery());
 
                 return $documentResponse;
-            }
+            },
         );
 
         $link = $api->previewSession('https://example.com/get-preview');
@@ -339,7 +339,7 @@ class ApiTest extends TestCase
         $this->expectException(InvalidPreviewToken::class);
         $this->expectExceptionMessage(
             'The preview url has been rejected because its host name '
-            . '"foobar.com" does not match the api host "example.com"'
+            . '"foobar.com" does not match the api host "example.com"',
         );
         $api->previewSession('https://foobar.com/something-nefarious');
     }
@@ -390,12 +390,12 @@ class ApiTest extends TestCase
                 $sentRequest = $request;
 
                 return $previewResponse;
-            }
+            },
         );
         self::assertNull(
             $api->previewSession(urlencode(
-                sprintf('https://%s/get-preview', $tokenHost)
-            ))
+                sprintf('https://%s/get-preview', $tokenHost),
+            )),
         );
         self::assertInstanceOf(RequestInterface::class, $sentRequest);
     }
@@ -491,7 +491,7 @@ class ApiTest extends TestCase
             new RequestFactory(),
             new UriFactory(),
             $rsFactory,
-            null
+            null,
         );
 
         $client->next($initialResultSet);
@@ -528,7 +528,7 @@ class ApiTest extends TestCase
             new RequestFactory(),
             new UriFactory(),
             $rsFactory,
-            null
+            null,
         );
 
         $client->previous($initialResultSet);

--- a/test/Unit/Document/DocumentDataConsumerTest.php
+++ b/test/Unit/Document/DocumentDataConsumerTest.php
@@ -23,8 +23,8 @@ class DocumentDataConsumerTest extends TestCase
         parent::setUp();
         $this->document = DocumentData::factory(
             Json::decodeObject(
-                $this->jsonFixtureByFileName('document.json')
-            )
+                $this->jsonFixtureByFileName('document.json'),
+            ),
         );
 
         $this->subject = new class ($this->document) implements Document

--- a/test/Unit/Document/Fragment/CollectionTest.php
+++ b/test/Unit/Document/Fragment/CollectionTest.php
@@ -21,7 +21,7 @@ class CollectionTest extends TestCase
     public function testAnEmptyCollectionIsConsideredEmpty(): void
     {
         $this->assertTrue(
-            Collection::new([])->isEmpty()
+            Collection::new([])->isEmpty(),
         );
     }
 
@@ -38,7 +38,7 @@ class CollectionTest extends TestCase
     public function testACollectionWithNonEmptyFragmentIsNotConsideredEmpty(): void
     {
         $this->assertFalse(
-            Collection::new([StringFragment::new('Foo')])->isEmpty()
+            Collection::new([StringFragment::new('Foo')])->isEmpty(),
         );
     }
 

--- a/test/Unit/Document/Fragment/EmbedTest.php
+++ b/test/Unit/Document/Fragment/EmbedTest.php
@@ -34,9 +34,7 @@ class EmbedTest extends TestCase
         return $tweet;
     }
 
-    /**
-     * @return Generator<array-key, array<Embed>>
-     */
+    /** @return Generator<array-key, array<Embed>> */
     public function embedProvider(): Generator
     {
         foreach ($this->embedCollection() as $key => $embed) {
@@ -77,9 +75,7 @@ class EmbedTest extends TestCase
         $this->assertArrayHasKey('provider_name', $attributes);
     }
 
-    /**
-     * @psalm-suppress InvalidArgument
-     */
+    /** @psalm-suppress InvalidArgument */
     public function testAnExceptionIsThrownSettingAnAttributeToANonScalarValue(): void
     {
         $this->expectException(InvalidArgument::class);
@@ -98,7 +94,7 @@ class EmbedTest extends TestCase
             '<html>',
             10,
             20,
-            []
+            [],
         );
 
         self::assertEquals('foo', $embed->type());

--- a/test/Unit/Document/Fragment/FactoryTest.php
+++ b/test/Unit/Document/Fragment/FactoryTest.php
@@ -169,7 +169,7 @@ class FactoryTest extends TestCase
 
     public function testThatAGeoPointCanBeDecoded(): void
     {
-        $fragment = Factory::factory(Json::decodeObject(<<<JSON
+        $fragment = Factory::factory(Json::decodeObject(<<<'JSON'
             {
                 "latitude": 0.12345,
                 "longitude": -1.23456
@@ -186,7 +186,7 @@ class FactoryTest extends TestCase
 
     public function testThatAGeoPointCanBeDecodedIfThePayloadContainsIntegers(): void
     {
-        $fragment = Factory::factory(Json::decodeObject(<<<JSON
+        $fragment = Factory::factory(Json::decodeObject(<<<'JSON'
             {
                 "latitude": 0,
                 "longitude": 1
@@ -204,7 +204,7 @@ class FactoryTest extends TestCase
     public function testThatAGeoPointIsNotDecodedIfTheValuesAreNotNumeric(): void
     {
         $this->expectException(UnexpectedValue::class);
-        Factory::factory(Json::decodeObject(<<<JSON
+        Factory::factory(Json::decodeObject(<<<'JSON'
             {
                 "latitude": "goat",
                 "longitude": "brains"

--- a/test/Unit/Document/Fragment/ImageLinkTest.php
+++ b/test/Unit/Document/Fragment/ImageLinkTest.php
@@ -16,7 +16,7 @@ class ImageLinkTest extends TestCase
             'filename',
             10,
             20,
-            30
+            30,
         );
 
         $this->expectNotToPerformAssertions();

--- a/test/Unit/Document/Fragment/ImageTest.php
+++ b/test/Unit/Document/Fragment/ImageTest.php
@@ -95,7 +95,7 @@ class ImageTest extends TestCase
         } catch (ImageViewNotFound $e) {
             self::assertStringContainsString(
                 'main, view-one, view-two',
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
     }

--- a/test/Unit/Document/Fragment/MediaLinkTest.php
+++ b/test/Unit/Document/Fragment/MediaLinkTest.php
@@ -14,7 +14,7 @@ class MediaLinkTest extends TestCase
         $link = MediaLink::new(
             'url',
             'filename',
-            10
+            10,
         );
 
         $this->expectNotToPerformAssertions();

--- a/test/Unit/Document/Fragment/RichTextTest.php
+++ b/test/Unit/Document/Fragment/RichTextTest.php
@@ -75,7 +75,7 @@ class RichTextTest extends TestCase
         $list = $richText->get(3);
         assert($list instanceof OrderedList);
 
-        $expect = <<<TEXT
+        $expect = <<<'TEXT'
             Ordered 1
             Ordered 2
             TEXT;

--- a/test/Unit/Document/Fragment/SliceTest.php
+++ b/test/Unit/Document/Fragment/SliceTest.php
@@ -68,7 +68,7 @@ class SliceTest extends TestCase
     /** @depends testThatASliceCanBeFound */
     public function testThatToStringWillYieldTheExpectedValue(Slice $slice): void
     {
-        $expect = <<<TEXT
+        $expect = <<<'TEXT'
             Heading 1
             Heading 2
             42

--- a/test/Unit/Document/Fragment/TextElementTest.php
+++ b/test/Unit/Document/Fragment/TextElementTest.php
@@ -16,7 +16,7 @@ class TextElementTest extends TestCase
             'paragraph',
             'Some Words',
             [],
-            'groovy'
+            'groovy',
         );
         $this->expectNotToPerformAssertions();
 

--- a/test/Unit/Framework/TestCase.php
+++ b/test/Unit/Framework/TestCase.php
@@ -18,7 +18,7 @@ abstract class TestCase extends PHPUnitTestCase
         if (! file_exists($path)) {
             $this->fail(sprintf(
                 'The JSON fixture %s does not exist',
-                $fileName
+                $fileName,
             ));
         }
 

--- a/test/Unit/JsonTest.php
+++ b/test/Unit/JsonTest.php
@@ -91,7 +91,7 @@ class JsonTest extends TestCase
             $this->assertInstanceOf(JsonException::class, $previous);
             $this->assertSame(
                 $error->getCode(),
-                $previous->getCode()
+                $previous->getCode(),
             );
         }
     }

--- a/test/Unit/PredicateTest.php
+++ b/test/Unit/PredicateTest.php
@@ -14,9 +14,7 @@ use function serialize;
 use function unserialize;
 use function var_export;
 
-/**
- * @psalm-import-type ArgType from Predicate
- */
+/** @psalm-import-type ArgType from Predicate */
 class PredicateTest extends TestCase
 {
     /** @return array<array-key, array{0: string, 1: scalar|list<scalar>, 2:string}> */

--- a/test/Unit/QueryTest.php
+++ b/test/Unit/QueryTest.php
@@ -83,9 +83,7 @@ class QueryTest extends TestCase
         return $queries;
     }
 
-    /**
-     * @dataProvider defaultUrlProvider
-     */
+    /** @dataProvider defaultUrlProvider */
     public function testDefaultUrl(Query $query, string $expectedUrl): void
     {
         $this->assertSame($expectedUrl, $query->toUrl());
@@ -122,15 +120,15 @@ class QueryTest extends TestCase
         $clone = $query->resultsPerPage(99);
         $this->assertStringContainsString(
             'pageSize=20',
-            $query->toUrl()
+            $query->toUrl(),
         );
         $this->assertStringContainsString(
             'pageSize=99',
-            $clone->toUrl()
+            $clone->toUrl(),
         );
         $this->assertStringNotContainsString(
             'pageSize=20',
-            $clone->toUrl()
+            $clone->toUrl(),
         );
     }
 
@@ -139,11 +137,11 @@ class QueryTest extends TestCase
     {
         $this->assertStringNotContainsString(
             'after=DOC_ID',
-            $query->toUrl()
+            $query->toUrl(),
         );
         $this->assertStringContainsString(
             'after=DOC_ID',
-            $query->after('DOC_ID')->toUrl()
+            $query->after('DOC_ID')->toUrl(),
         );
     }
 
@@ -152,11 +150,11 @@ class QueryTest extends TestCase
     {
         $this->assertStringContainsString(
             'page=1',
-            $query->toUrl()
+            $query->toUrl(),
         );
         $this->assertStringContainsString(
             'page=99',
-            $query->page(99)->toUrl()
+            $query->page(99)->toUrl(),
         );
     }
 
@@ -165,7 +163,7 @@ class QueryTest extends TestCase
     {
         $this->assertStringNotContainsString(
             'fetchLinks',
-            $query->toUrl()
+            $query->toUrl(),
         );
     }
 
@@ -174,7 +172,7 @@ class QueryTest extends TestCase
     {
         $this->assertStringNotContainsString(
             'fetch',
-            $query->toUrl()
+            $query->toUrl(),
         );
     }
 
@@ -183,7 +181,7 @@ class QueryTest extends TestCase
     {
         $this->assertStringContainsString(
             urlencode('first,second'),
-            $query->fetch('first', 'second')->toUrl()
+            $query->fetch('first', 'second')->toUrl(),
         );
     }
 
@@ -192,7 +190,7 @@ class QueryTest extends TestCase
     {
         $this->assertStringContainsString(
             urlencode('first,second'),
-            $query->fetch(...['first', 'second'])->toUrl()
+            $query->fetch(...['first', 'second'])->toUrl(),
         );
     }
 
@@ -201,7 +199,7 @@ class QueryTest extends TestCase
     {
         $this->assertStringContainsString(
             urlencode('first,second'),
-            $query->fetchLinks(...['first', 'second'])->toUrl()
+            $query->fetchLinks(...['first', 'second'])->toUrl(),
         );
     }
 
@@ -210,7 +208,7 @@ class QueryTest extends TestCase
     {
         $this->assertStringNotContainsString(
             'fetch=',
-            $query->fetch('first', 'second')->fetch()->toUrl()
+            $query->fetch('first', 'second')->fetch()->toUrl(),
         );
     }
 
@@ -219,7 +217,7 @@ class QueryTest extends TestCase
     {
         $this->assertStringNotContainsString(
             'fetchLinks=',
-            $query->fetchLinks('first', 'second')->fetchLinks()->toUrl()
+            $query->fetchLinks('first', 'second')->fetchLinks()->toUrl(),
         );
     }
 
@@ -271,7 +269,7 @@ class QueryTest extends TestCase
         $expect = urlencode('[a,b,c]');
         $this->assertStringContainsString(
             $expect,
-            $query->order('a', 'b', 'c')->toUrl()
+            $query->order('a', 'b', 'c')->toUrl(),
         );
     }
 
@@ -281,7 +279,7 @@ class QueryTest extends TestCase
         $expect = urlencode('[a,b,c]');
         $this->assertStringNotContainsString(
             $expect,
-            $query->order('a', 'b', 'c')->order()->toUrl()
+            $query->order('a', 'b', 'c')->order()->toUrl(),
         );
     }
 }

--- a/test/Unit/Serializer/HtmlSerializerTest.php
+++ b/test/Unit/Serializer/HtmlSerializerTest.php
@@ -64,8 +64,8 @@ class HtmlSerializerTest extends TestCase
     {
         $document = DocumentData::factory(
             Json::decodeObject(
-                $this->jsonFixtureByFileName('document.json')
-            )
+                $this->jsonFixtureByFileName('document.json'),
+            ),
         );
 
         ($this->serializer)($document->content());
@@ -152,13 +152,11 @@ class HtmlSerializerTest extends TestCase
         $richText = $this->richTextSpansFixture();
         $this->assertEquals(
             $expectedMarkup,
-            ($this->serializer)($richText->get($fragmentIndex))
+            ($this->serializer)($richText->get($fragmentIndex)),
         );
     }
 
-    /**
-     * @return array<string, array{0: int, 1: string}>
-     */
+    /** @return array<string, array{0: int, 1: string}> */
     public function richTextBlockElementsData(): array
     {
         return [
@@ -208,7 +206,7 @@ class HtmlSerializerTest extends TestCase
         $fragment = $richText->get($fragmentIndex);
         self::assertEquals(
             $expectedMarkup,
-            ($this->serializer)($fragment)
+            ($this->serializer)($fragment),
         );
     }
 

--- a/test/Unit/Value/ApiDataTest.php
+++ b/test/Unit/Value/ApiDataTest.php
@@ -16,9 +16,7 @@ use PrismicTest\Framework\TestCase;
 
 use function sprintf;
 
-/**
- * @psalm-suppress DeprecatedClass, DeprecatedMethod
- */
+/** @psalm-suppress DeprecatedClass, DeprecatedMethod */
 class ApiDataTest extends TestCase
 {
     /** @var ApiData */
@@ -31,9 +29,7 @@ class ApiDataTest extends TestCase
         $this->apiData = ApiData::factory(Json::decodeObject($payload));
     }
 
-    /**
-     * @psalm-suppress DeprecatedMethod
-     */
+    /** @psalm-suppress DeprecatedMethod */
     public function testTagsHaveExpectedValue(): void
     {
         self::assertContainsEquals('goats', $this->apiData->tags());
@@ -90,18 +86,14 @@ class ApiDataTest extends TestCase
         $this->apiData->bookmark('not-found');
     }
 
-    /**
-     * @psalm-suppress DeprecatedMethod
-     */
+    /** @psalm-suppress DeprecatedMethod */
     public function testThatAnEmptyTagsArrayIsAcceptable(): void
     {
         $data = ApiData::factory(Json::decodeObject($this->jsonFixtureByFileName('api-data-with-empty-tags.json')));
         self::assertEmpty($data->tags());
     }
 
-    /**
-     * @psalm-suppress DeprecatedMethod
-     */
+    /** @psalm-suppress DeprecatedMethod */
     public function testThatAMissingTagsPropertyInTheDataPayloadIsAcceptable(): void
     {
         $data = ApiData::factory(Json::decodeObject($this->jsonFixtureByFileName('api-data-missing-tags.json')));
@@ -134,7 +126,7 @@ class ApiDataTest extends TestCase
             self::assertContains(
                 $language->id(),
                 $expect,
-                sprintf('Language "%s" is not present in the expected list of values', $language->id())
+                sprintf('Language "%s" is not present in the expected list of values', $language->id()),
             );
         }
     }

--- a/test/Unit/Value/BookmarkTest.php
+++ b/test/Unit/Value/BookmarkTest.php
@@ -7,9 +7,7 @@ namespace PrismicTest\Value;
 use Prismic\Value\Bookmark;
 use PrismicTest\Framework\TestCase;
 
-/**
- * @psalm-suppress DeprecatedClass
- */
+/** @psalm-suppress DeprecatedClass */
 class BookmarkTest extends TestCase
 {
     public function testNewInstance(): void

--- a/test/Unit/Value/DocumentDataTest.php
+++ b/test/Unit/Value/DocumentDataTest.php
@@ -31,8 +31,8 @@ class DocumentDataTest extends TestCase
         parent::setUp();
         $this->document = DocumentData::factory(
             Json::decodeObject(
-                $this->jsonFixtureByFileName('document.json')
-            )
+                $this->jsonFixtureByFileName('document.json'),
+            ),
         );
     }
 
@@ -60,7 +60,7 @@ class DocumentDataTest extends TestCase
     {
         $this->assertSame(
             '2020-01-01 01:23:45 0',
-            $this->document->firstPublished()->format('Y-m-d H:i:s Z')
+            $this->document->firstPublished()->format('Y-m-d H:i:s Z'),
         );
     }
 
@@ -68,7 +68,7 @@ class DocumentDataTest extends TestCase
     {
         $this->assertSame(
             '2020-01-02 01:23:45 0',
-            $this->document->lastPublished()->format('Y-m-d H:i:s Z')
+            $this->document->lastPublished()->format('Y-m-d H:i:s Z'),
         );
     }
 
@@ -98,7 +98,7 @@ class DocumentDataTest extends TestCase
         assert($date instanceof DateFragment);
         $this->assertSame(
             '2020-02-03 00:00:00 0',
-            $date->format('Y-m-d H:i:s Z')
+            $date->format('Y-m-d H:i:s Z'),
         );
     }
 
@@ -108,7 +108,7 @@ class DocumentDataTest extends TestCase
         assert($date instanceof DateFragment);
         $this->assertSame(
             '2020-02-03 12:13:14 0',
-            $date->format('Y-m-d H:i:s Z')
+            $date->format('Y-m-d H:i:s Z'),
         );
     }
 
@@ -166,8 +166,8 @@ class DocumentDataTest extends TestCase
     {
         $data = DocumentData::factory(
             Json::decodeObject(
-                $this->jsonFixtureByFileName('document-lacking-pub-date.json')
-            )
+                $this->jsonFixtureByFileName('document-lacking-pub-date.json'),
+            ),
         );
 
         $minute = new DateInterval('PT60S');

--- a/test/Unit/Value/FormSpecTest.php
+++ b/test/Unit/Value/FormSpecTest.php
@@ -17,7 +17,7 @@ class FormSpecTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $json = <<<EOF
+        $json = <<<'EOF'
         {
             "name" : "My Form",
             "rel" : "something",

--- a/test/Unit/Value/TypeTest.php
+++ b/test/Unit/Value/TypeTest.php
@@ -24,7 +24,7 @@ class TypeTest extends TestCase
     {
         self::assertEquals(
             '{"foo":"bar"}',
-            json_encode(Type::new('foo', 'bar'), JSON_THROW_ON_ERROR)
+            json_encode(Type::new('foo', 'bar'), JSON_THROW_ON_ERROR),
         );
     }
 


### PR DESCRIPTION
- Trailing commas in calls and parameter lists
- Single line doc blocks
- Require nowdoc instead of heredoc