### PR TITLE
Reduce Dependabot noise for actions

### DIFF
--- a/.github/workflows/merge-dependabot-upgrades.yml
+++ b/.github/workflows/merge-dependabot-upgrades.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Auto-Merge
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: ridedott/merge-me-action@v2.10.12
+        uses: ridedott/merge-me-action@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_METHOD: MERGE


### PR DESCRIPTION
Pin mergeme action to a major to reduce commit history noise