### PR TITLE
Quick fix for breaking changes in the REST API

### DIFF
--- a/src/Document/Fragment/Factory.php
+++ b/src/Document/Fragment/Factory.php
@@ -134,7 +134,15 @@ final class Factory
     private static function imageFactory(object $data, string $name = 'main'): Image
     {
         $values = get_object_vars($data);
-        unset($values['dimensions'], $values['alt'], $values['copyright'], $values['url'], $values['linkTo']);
+        unset(
+            $values['dimensions'],
+            $values['alt'],
+            $values['copyright'],
+            $values['url'],
+            $values['linkTo'],
+            $values['edit'],
+        );
+
         $views = [];
         foreach ($values as $viewName => $view) {
             if (! is_object($view)) {


### PR DESCRIPTION
@Prismicio have added a new property to images called `edit`.

No announcement. Fuck it, let's just change the shape of our response without telling anyone. Muppets.

Releasing this, untested, in the next minor - will probably have to back port the fix too.