### PR TITLE
Deal with removal of the bookmarks property

### DIFF
--- a/src/Value/ApiData.php
+++ b/src/Value/ApiData.php
@@ -11,6 +11,7 @@ use Prismic\Exception\UnknownForm;
 use function array_keys;
 use function array_map;
 use function get_object_vars;
+use function is_object;
 
 /** @psalm-suppress DeprecatedClass, DeprecatedMethod */
 final class ApiData
@@ -37,7 +38,9 @@ final class ApiData
 
     public static function factory(object $payload): ApiData
     {
-        $bookmarks = get_object_vars(self::assertObjectPropertyIsObject($payload, 'bookmarks'));
+        /** @var mixed $bookmarks */
+        $bookmarks = $payload->bookmarks ?? null;
+        $bookmarks = is_object($bookmarks) ? (array) $bookmarks : [];
         $types = get_object_vars(self::assertObjectPropertyIsObject($payload, 'types'));
         /** @var string[] $tags */
         $tags = self::optionalArrayProperty($payload, 'tags') ?? [];

--- a/src/Value/ApiData.php
+++ b/src/Value/ApiData.php
@@ -40,6 +40,7 @@ final class ApiData
     {
         /** @var mixed $bookmarks */
         $bookmarks = $payload->bookmarks ?? null;
+        /** @psalm-var array<string, string> $bookmarks */
         $bookmarks = is_object($bookmarks) ? (array) $bookmarks : [];
         $types = get_object_vars(self::assertObjectPropertyIsObject($payload, 'types'));
         /** @var string[] $tags */

--- a/test/Smoke/ApiTest.php
+++ b/test/Smoke/ApiTest.php
@@ -54,6 +54,17 @@ class ApiTest extends TestCase
         foreach (self::apiInstances() as $api) {
             assert($api instanceof Api);
             foreach ($api->data()->types() as $type) {
+                $exists = $api->query(
+                    $api->createQuery()
+                        ->resultsPerPage(1)
+                        ->query(Predicate::at('document.type', $type->id())),
+                );
+
+                // Prevent issues querying docs where there are zero published docs for the type
+                if ($exists->count() === 0) {
+                    continue;
+                }
+
                 $response = $api->query(
                     $api->createQuery()
                         ->resultsPerPage(1)

--- a/test/Unit/Value/ApiDataTest.php
+++ b/test/Unit/Value/ApiDataTest.php
@@ -94,6 +94,13 @@ class ApiDataTest extends TestCase
     }
 
     /** @psalm-suppress DeprecatedMethod */
+    public function testThatAMissingBookmarksStructureIsAcceptable(): void
+    {
+        $data = ApiData::factory(Json::decodeObject($this->jsonFixtureByFileName('api-data-without-bookmarks.json')));
+        self::assertEmpty($data->bookmarks());
+    }
+
+    /** @psalm-suppress DeprecatedMethod */
     public function testThatAMissingTagsPropertyInTheDataPayloadIsAcceptable(): void
     {
         $data = ApiData::factory(Json::decodeObject($this->jsonFixtureByFileName('api-data-missing-tags.json')));

--- a/test/fixture/api-data-without-bookmarks.json
+++ b/test/fixture/api-data-without-bookmarks.json
@@ -1,0 +1,78 @@
+{
+    "refs": [
+        {
+            "id": "master",
+            "ref": "master-ref",
+            "label": "Master",
+            "isMasterRef": true
+        }
+    ],
+    "types": {
+        "basic-document": "Basic Document Type"
+    },
+    "languages": [
+        {
+            "id": "en-gb",
+            "name": "English - Great Britain"
+        }
+    ],
+    "forms": {
+        "everything": {
+            "method": "GET",
+            "enctype": "application/x-www-form-urlencoded",
+            "action": "https://repo.cdn.prismic.io/api/v2/documents/search",
+            "fields": {
+                "ref": {
+                    "type": "String",
+                    "multiple": false
+                },
+                "q": {
+                    "type": "String",
+                    "multiple": true
+                },
+                "lang": {
+                    "type": "String",
+                    "multiple": false
+                },
+                "page": {
+                    "type": "Integer",
+                    "multiple": false,
+                    "default": "1"
+                },
+                "pageSize": {
+                    "type": "Integer",
+                    "multiple": false,
+                    "default": "20"
+                },
+                "after": {
+                    "type": "String",
+                    "multiple": false
+                },
+                "fetch": {
+                    "type": "String",
+                    "multiple": false
+                },
+                "fetchLinks": {
+                    "type": "String",
+                    "multiple": false
+                },
+                "orderings": {
+                    "type": "String",
+                    "multiple": false
+                },
+                "referer": {
+                    "type": "String",
+                    "multiple": false
+                }
+            }
+        }
+    },
+    "oauth_initiate": "https://repo.prismic.io/auth",
+    "oauth_token": "https://repo.prismic.io/auth/token",
+    "version": "068d573",
+    "license": "This work is licensed under the Creative Commons Attribution 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by/4.0/.",
+    "experiments": {
+        "draft": [],
+        "running": []
+    }
+}


### PR DESCRIPTION
Prismic are removing the bookmarks property from the API payload in February 2025.

This patch removes the hard requirement for it during parsing of the payload.

> We’re writing to inform you about two important updates to the Prismic Content API,
> specifically affecting the /api endpoint. These changes will take effect on
> February 12, 2025:
>
> ## Removal of Bookmarks:
> Bookmarks, a deprecated feature, will be permanently removed from the /api endpoint.
> This feature was used prior to the introduction of the Single Type and UID field,
> which now provide better alternatives.
