### PR TITLE
Add support for the new Tables feature

### DIFF
--- a/src/Document/Fragment/Factory.php
+++ b/src/Document/Fragment/Factory.php
@@ -12,6 +12,7 @@ use Prismic\Value\DataAssertionBehaviour;
 use function array_filter;
 use function array_keys;
 use function array_map;
+use function array_values;
 use function assert;
 use function count;
 use function get_object_vars;
@@ -26,6 +27,12 @@ use function preg_match;
 use function property_exists;
 use function strpos;
 
+/**
+ * @psalm-type TableShape = object{
+ *     head?: object{rows: non-empty-list<object>},
+ *     body?: object{rows: non-empty-list<object>},
+ * }
+ */
 final class Factory
 {
     use DataAssertionBehaviour;
@@ -79,6 +86,11 @@ final class Factory
 
     private static function objectFactory(object $data): Fragment
     {
+        if (self::isTable($data)) {
+            /** @psalm-var TableShape $data */
+            return self::tableFactory($data);
+        }
+
         if (property_exists($data, 'dimensions')) {
             return self::imageFactory($data);
         }
@@ -311,7 +323,7 @@ final class Factory
     }
 
     /** @param mixed[] $data */
-    private static function arrayFactory(array $data): Fragment
+    private static function arrayFactory(array $data): RichText|Collection
     {
         $fragments = [];
         $richText = false;
@@ -328,5 +340,73 @@ final class Factory
         return $richText
             ? RichText::new($fragments)
             : Collection::new($fragments);
+    }
+
+    private static function isTable(object $data): bool
+    {
+        return (
+            property_exists($data, 'head')
+            &&
+            is_object($data->head)
+            &&
+            property_exists($data->head, 'rows')
+            &&
+            is_array($data->head->rows)
+        ) || (
+            property_exists($data, 'body')
+            &&
+            is_object($data->body)
+            &&
+            property_exists($data->body, 'rows')
+            &&
+            is_array($data->body->rows)
+        );
+    }
+
+    /** @param TableShape $data */
+    private static function tableFactory(object $data): Table
+    {
+        $head = null;
+        if (property_exists($data, 'head')) {
+            $head = self::tableRowFactory($data->head->rows[0]);
+        }
+
+        $body = [];
+
+        if (property_exists($data, 'body')) {
+            $body = array_map(
+                self::tableRowFactory(...),
+                $data->body->rows,
+            );
+        }
+
+        return new Table($head, $body);
+    }
+
+    private static function tableRowFactory(object $row): TableRow
+    {
+        assert(isset($row->key) && is_string($row->key) && $row->key !== '');
+        assert(isset($row->cells) && is_array($row->cells) && count($row->cells) > 0);
+
+        return new TableRow(
+            $row->key,
+            array_values(array_map(
+                self::tableCellFactory(...),
+                $row->cells,
+            )),
+        );
+    }
+
+    private static function tableCellFactory(object $cell): TableCell
+    {
+        assert(isset($cell->key) && is_string($cell->key) && $cell->key !== '');
+        assert(isset($cell->type));
+        assert($cell->type === TableCell::TYPE_HEADER || $cell->type === TableCell::TYPE_DATA);
+        assert(isset($cell->content) && is_array($cell->content));
+
+        $content = self::arrayFactory($cell->content);
+        assert($content instanceof RichText);
+
+        return new TableCell($cell->key, $cell->type, $content);
     }
 }

--- a/src/Document/Fragment/Table.php
+++ b/src/Document/Fragment/Table.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prismic\Document\Fragment;
+
+use Override;
+use Prismic\Document\Fragment;
+
+use function count;
+
+final readonly class Table implements Fragment
+{
+    /** @param list<TableRow> $body */
+    public function __construct(
+        public TableRow|null $head,
+        public array $body,
+    ) {
+    }
+
+    #[Override]
+    public function isEmpty(): bool
+    {
+        if ($this->head !== null && ! $this->head->isEmpty()) {
+            return false;
+        }
+
+        foreach ($this->body as $row) {
+            if ($row->isEmpty()) {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /** @psalm-assert-if-true TableRow $this->head */
+    public function hasHead(): bool
+    {
+        return $this->head !== null;
+    }
+
+    /** @psalm-assert-if-true non-empty-list<TableRow> $this->body */
+    public function hasBody(): bool
+    {
+        return count($this->body) > 0;
+    }
+}

--- a/src/Document/Fragment/TableCell.php
+++ b/src/Document/Fragment/TableCell.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prismic\Document\Fragment;
+
+use Override;
+use Prismic\Document\Fragment;
+
+final readonly class TableCell implements Fragment
+{
+    public const TYPE_HEADER = 'header';
+    public const TYPE_DATA = 'data';
+
+    /**
+     * @param non-empty-string                  $key
+     * @param self::TYPE_HEADER|self::TYPE_DATA $type
+     */
+    public function __construct(
+        public string $key,
+        public string $type,
+        public RichText|null $content,
+    ) {
+    }
+
+    public function isHeaderCell(): bool
+    {
+        return $this->type === self::TYPE_HEADER;
+    }
+
+    #[Override]
+    public function isEmpty(): bool
+    {
+        return $this->content === null || $this->content->isEmpty();
+    }
+}

--- a/src/Document/Fragment/TableRow.php
+++ b/src/Document/Fragment/TableRow.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prismic\Document\Fragment;
+
+use ArrayIterator;
+use IteratorAggregate;
+use Override;
+use Prismic\Document\Fragment;
+use Traversable;
+
+/** @implements IteratorAggregate<int, TableCell> */
+final readonly class TableRow implements Fragment, IteratorAggregate
+{
+    /**
+     * @param non-empty-string          $key
+     * @param non-empty-list<TableCell> $cells
+     */
+    public function __construct(
+        public string $key,
+        public array $cells,
+    ) {
+    }
+
+    #[Override]
+    public function isEmpty(): bool
+    {
+        foreach ($this->cells as $cell) {
+            if ($cell->isEmpty()) {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /** @return Traversable<int, TableCell> */
+    #[Override]
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->cells);
+    }
+}

--- a/src/Serializer/HtmlSerializer.php
+++ b/src/Serializer/HtmlSerializer.php
@@ -24,6 +24,9 @@ use Prismic\Document\Fragment\OrderedList;
 use Prismic\Document\Fragment\Slice;
 use Prismic\Document\Fragment\Span;
 use Prismic\Document\Fragment\StringFragment;
+use Prismic\Document\Fragment\Table;
+use Prismic\Document\Fragment\TableCell;
+use Prismic\Document\Fragment\TableRow;
 use Prismic\Document\Fragment\TextElement;
 use Prismic\Document\Fragment\WebLink;
 use Prismic\Document\FragmentCollection;
@@ -150,6 +153,9 @@ class HtmlSerializer
 
             case Embed::class:
                 return $this->embed($fragment);
+
+            case Table::class:
+                return $this->table($fragment);
         }
 
         throw new UnexpectedValue(sprintf(
@@ -361,6 +367,53 @@ class HtmlSerializer
             '<div%1$s>%2$s</div>',
             $attributes,
             (string) $embed->html(),
+        );
+    }
+
+    private function table(Table $table): string
+    {
+        if ($table->isEmpty()) {
+            return '';
+        }
+
+        $head = $table->hasHead()
+            ? sprintf('<thead>%s</thead>', $this->tableRow($table->head))
+            : '';
+
+        $body = $table->hasBody()
+            ? sprintf(
+                '<tbody>%s</tbody>',
+                implode('', array_map(
+                    $this->tableRow(...),
+                    $table->body,
+                )),
+            )
+            : '';
+
+        return sprintf('<table>%s%s</table>', $head, $body);
+    }
+
+    private function tableRow(TableRow $row): string
+    {
+        $cells = implode('', array_map(
+            function (TableCell $cell): string {
+                $tag = $cell->isHeaderCell() ? 'th' : 'td';
+                $content = $cell->content === null || $cell->content->isEmpty()
+                    ? ''
+                    : ($this)($cell->content);
+
+                return sprintf(
+                    '<%1$s>%2$s</%1$s>',
+                    $tag,
+                    $content,
+                );
+            },
+            $row->cells,
+        ));
+
+        return sprintf(
+            '<tr>%s</tr>',
+            $cells,
         );
     }
 }

--- a/test/Unit/Document/Fragment/FactoryTest.php
+++ b/test/Unit/Document/Fragment/FactoryTest.php
@@ -20,9 +20,11 @@ use Prismic\Document\FragmentCollection;
 use Prismic\Exception\InvalidArgument;
 use Prismic\Exception\UnexpectedValue;
 use Prismic\Json;
+use Prismic\Value\DocumentData;
 use PrismicTest\Framework\TestCase;
 
 use function assert;
+use function file_get_contents;
 
 final class FactoryTest extends TestCase
 {
@@ -321,5 +323,27 @@ final class FactoryTest extends TestCase
 
         self::assertNull($slice->version());
         self::assertNull($slice->variation());
+    }
+
+    /** @return list<array{0: non-empty-string}> */
+    public static function tableFixtureProvider(): array
+    {
+        return [
+            [__DIR__ . '/../../../fixture/tables/body-only.json'],
+            [__DIR__ . '/../../../fixture/tables/both-header-and-footer.json'],
+            [__DIR__ . '/../../../fixture/tables/empty-body.json'],
+            [__DIR__ . '/../../../fixture/tables/header-only.json'],
+        ];
+    }
+
+    #[DataProvider('tableFixtureProvider')]
+    public function testTables(string $fixture): void
+    {
+        $json = file_get_contents($fixture);
+        assert($json !== false);
+        $document = DocumentData::factory(Json::decodeObject($json));
+
+        $table = $document->content()->get('table');
+        self::assertInstanceOf(Fragment\Table::class, $table);
     }
 }

--- a/test/Unit/Document/Fragment/TableTest.php
+++ b/test/Unit/Document/Fragment/TableTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrismicTest\Document\Fragment;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Prismic\Document\Fragment\Table;
+use Prismic\Json;
+use Prismic\Value\DocumentData;
+
+use function assert;
+use function file_get_contents;
+
+final class TableTest extends TestCase
+{
+    /**
+     * @return list<array{
+     *     fixture: non-empty-string,
+     *     hasHead: bool,
+     *     hasBody: bool,
+     *     isEmpty: bool,
+     * }>
+     */
+    public static function tableFixtureProvider(): array
+    {
+        return [
+            [
+                'fixture' => __DIR__ . '/../../../fixture/tables/body-only.json',
+                'hasHead' => false,
+                'hasBody' => true,
+                'isEmpty' => false,
+            ],
+            [
+                'fixture' => __DIR__ . '/../../../fixture/tables/both-header-and-footer.json',
+                'hasHead' => true,
+                'hasBody' => true,
+                'isEmpty' => false,
+            ],
+            [
+                'fixture' => __DIR__ . '/../../../fixture/tables/empty-body.json',
+                'hasHead' => false,
+                'hasBody' => true,
+                'isEmpty' => true,
+            ],
+            [
+                'fixture' => __DIR__ . '/../../../fixture/tables/header-only.json',
+                'hasHead' => true,
+                'hasBody' => false,
+                'isEmpty' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('tableFixtureProvider')]
+    public function testTables(string $fixture, bool $hasHead, bool $hasBody, bool $isEmpty): void
+    {
+        $json = file_get_contents($fixture);
+        assert($json !== false);
+        $document = DocumentData::factory(Json::decodeObject($json));
+
+        $table = $document->content()->get('table');
+        self::assertInstanceOf(Table::class, $table);
+
+        self::assertSame($hasHead, $table->hasHead());
+        self::assertSame($hasBody, $table->hasBody());
+        self::assertSame($isEmpty, $table->isEmpty());
+
+        foreach ($table->body as $row) {
+            self::assertNotEmpty($row->key);
+            foreach ($row as $cell) {
+                self::assertFalse($cell->isHeaderCell());
+                self::assertNotEmpty($cell->key);
+            }
+        }
+
+        if (! $table->hasHead()) {
+            return;
+        }
+
+        foreach ($table->head as $cell) {
+            self::assertTrue($cell->isHeaderCell());
+            self::assertNotEmpty($cell->key);
+        }
+    }
+}

--- a/test/Unit/Serializer/HtmlSerializerTest.php
+++ b/test/Unit/Serializer/HtmlSerializerTest.php
@@ -247,4 +247,113 @@ final class HtmlSerializerTest extends TestCase
 
         self::assertEquals($expect, ($this->serializer)($embed));
     }
+
+    public function testTableMarkupWithHeadOnly(): void
+    {
+        $content = RichText::new([
+            Fragment\TextElement::new('paragraph', 'Foo', [], null),
+        ]);
+
+        $table = new Fragment\Table(
+            new Fragment\TableRow(
+                'foo',
+                [
+                    new Fragment\TableCell(
+                        'foo',
+                        Fragment\TableCell::TYPE_HEADER,
+                        $content,
+                    ),
+                    new Fragment\TableCell(
+                        'foo',
+                        Fragment\TableCell::TYPE_HEADER,
+                        $content,
+                    ),
+                ],
+            ),
+            [],
+        );
+
+        $expect = '<table><thead><tr><th><p>Foo</p></th><th><p>Foo</p></th></tr></thead></table>';
+
+        self::assertSame(
+            $expect,
+            $this->serializer->__invoke($table),
+        );
+    }
+
+    public function testEmptyTableYieldsEmptyString(): void
+    {
+        $table = new Fragment\Table(null, []);
+        self::assertSame('', $this->serializer->__invoke($table));
+    }
+
+    public function testTableWithoutHead(): void
+    {
+        $content = RichText::new([
+            Fragment\TextElement::new('paragraph', 'Foo', [], null),
+        ]);
+
+        $table = new Fragment\Table(
+            null,
+            [
+                new Fragment\TableRow(
+                    'foo',
+                    [
+                        new Fragment\TableCell(
+                            'foo',
+                            Fragment\TableCell::TYPE_DATA,
+                            $content,
+                        ),
+                        new Fragment\TableCell(
+                            'foo',
+                            Fragment\TableCell::TYPE_DATA,
+                            $content,
+                        ),
+                    ],
+                ),
+            ],
+        );
+
+        $expect = '<table><tbody><tr><td><p>Foo</p></td><td><p>Foo</p></td></tr></tbody></table>';
+
+        self::assertSame(
+            $expect,
+            $this->serializer->__invoke($table),
+        );
+    }
+
+    public function testEmptyTableContentYieldsEmptyCells(): void
+    {
+        $table = new Fragment\Table(
+            null,
+            [
+                new Fragment\TableRow(
+                    'foo',
+                    [
+                        new Fragment\TableCell(
+                            'foo',
+                            Fragment\TableCell::TYPE_DATA,
+                            RichText::new([
+                                Fragment\TextElement::new('paragraph', 'Foo', [], null),
+                            ]),
+                        ),
+                        new Fragment\TableCell(
+                            'foo',
+                            Fragment\TableCell::TYPE_DATA,
+                            RichText::new([
+                                Fragment\TextElement::new('paragraph', '', [], null),
+                            ]),
+                        ),
+                    ],
+                ),
+            ],
+        );
+
+        $expect = '<table><tbody><tr><td><p>Foo</p></td><td></td></tr></tbody></table>';
+
+        self::assertSame(
+            $expect,
+            $this->serializer->__invoke($table),
+        );
+    }
 }

--- a/test/fixture/tables/body-only.json
+++ b/test/fixture/tables/body-only.json
@@ -1,0 +1,128 @@
+{
+    "id": "whatever",
+    "uid": "home",
+    "url": null,
+    "type": "page",
+    "href": "https://whatever.cdn.prismic.io/api/v2/documents/search?ref=foo",
+    "tags": [],
+    "first_publication_date": "2025-03-26T15:43:27+0000",
+    "last_publication_date": "2025-03-26T15:43:27+0000",
+    "slugs": [],
+    "linked_documents": [],
+    "lang": "en-gb",
+    "alternate_languages": [],
+    "data": {
+        "table": {
+            "body": {
+                "rows": [
+                    {
+                        "key": "5cd199a8-d4ff-4b36-b1d1-0ac0b81ef335",
+                        "cells": [
+                            {
+                                "key": "d07b7f4b-f597-45ea-b0fa-a8ad3fe269be",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "1",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "2b03c2ba-950b-4223-a818-643d8c73b68d",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "2",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "afe82840-58fd-4073-b175-c4dc33fafca7",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "3",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "bb63fa01-c413-4e53-a62d-aa116e0b1a28",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "4",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "key": "271e3410-706c-4d9c-853b-00222c2594ab",
+                        "cells": [
+                            {
+                                "key": "437a1305-8238-4f3c-8d46-c07d30e67591",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "71895248-767e-468c-a016-ddd7fc336c28",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "2b9a9188-d6d3-4d7c-87aa-860f63c90764",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "85c99517-7dae-4170-8a58-177d35a02f0d",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/test/fixture/tables/both-header-and-footer.json
+++ b/test/fixture/tables/both-header-and-footer.json
@@ -1,0 +1,185 @@
+{
+    "id": "whatever",
+    "uid": "home",
+    "url": null,
+    "type": "page",
+    "href": "https://whatever.cdn.prismic.io/api/v2/documents/search?ref=foo",
+    "tags": [],
+    "first_publication_date": "2025-03-26T15:43:27+0000",
+    "last_publication_date": "2025-03-26T15:43:27+0000",
+    "slugs": [],
+    "linked_documents": [],
+    "lang": "en-gb",
+    "alternate_languages": [],
+    "data": {
+        "table": {
+            "head": {
+                "rows": [
+                    {
+                        "key": "ac95733e-4a36-4659-b385-aa25a4a73628",
+                        "cells": [
+                            {
+                                "key": "a4f61d62-34e7-402c-b963-0f3a2b3177aa",
+                                "type": "header",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "Foo",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "66e97446-f41c-436a-9334-2c86193b401e",
+                                "type": "header",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "Bar",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "407ce876-6bb4-45c4-bba2-c54a26b26891",
+                                "type": "header",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "Baz",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "050fcd50-ead6-4959-9348-fa4d51fd8235",
+                                "type": "header",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "Bat",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "body": {
+                "rows": [
+                    {
+                        "key": "5cd199a8-d4ff-4b36-b1d1-0ac0b81ef335",
+                        "cells": [
+                            {
+                                "key": "d07b7f4b-f597-45ea-b0fa-a8ad3fe269be",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "1",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "2b03c2ba-950b-4223-a818-643d8c73b68d",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "2",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "afe82840-58fd-4073-b175-c4dc33fafca7",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "3",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "bb63fa01-c413-4e53-a62d-aa116e0b1a28",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "4",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "key": "271e3410-706c-4d9c-853b-00222c2594ab",
+                        "cells": [
+                            {
+                                "key": "437a1305-8238-4f3c-8d46-c07d30e67591",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "71895248-767e-468c-a016-ddd7fc336c28",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "2b9a9188-d6d3-4d7c-87aa-860f63c90764",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "85c99517-7dae-4170-8a58-177d35a02f0d",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/test/fixture/tables/empty-body.json
+++ b/test/fixture/tables/empty-body.json
@@ -1,0 +1,75 @@
+{
+    "id": "whatever",
+    "uid": "home",
+    "url": null,
+    "type": "page",
+    "href": "https://whatever.cdn.prismic.io/api/v2/documents/search?ref=foo",
+    "tags": [],
+    "first_publication_date": "2025-03-26T15:43:27+0000",
+    "last_publication_date": "2025-03-26T15:43:27+0000",
+    "slugs": [],
+    "linked_documents": [],
+    "lang": "en-gb",
+    "alternate_languages": [],
+    "data": {
+        "table": {
+            "body": {
+                "rows": [
+                    {
+                        "key": "271e3410-706c-4d9c-853b-00222c2594ab",
+                        "cells": [
+                            {
+                                "key": "437a1305-8238-4f3c-8d46-c07d30e67591",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "71895248-767e-468c-a016-ddd7fc336c28",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "2b9a9188-d6d3-4d7c-87aa-860f63c90764",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "85c99517-7dae-4170-8a58-177d35a02f0d",
+                                "type": "data",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/test/fixture/tables/header-only.json
+++ b/test/fixture/tables/header-only.json
@@ -1,0 +1,75 @@
+{
+    "id": "whatever",
+    "uid": "home",
+    "url": null,
+    "type": "page",
+    "href": "https://whatever.cdn.prismic.io/api/v2/documents/search?ref=foo",
+    "tags": [],
+    "first_publication_date": "2025-03-26T15:43:27+0000",
+    "last_publication_date": "2025-03-26T15:43:27+0000",
+    "slugs": [],
+    "linked_documents": [],
+    "lang": "en-gb",
+    "alternate_languages": [],
+    "data": {
+        "table": {
+            "head": {
+                "rows": [
+                    {
+                        "key": "ac95733e-4a36-4659-b385-aa25a4a73628",
+                        "cells": [
+                            {
+                                "key": "a4f61d62-34e7-402c-b963-0f3a2b3177aa",
+                                "type": "header",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "Foo",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "66e97446-f41c-436a-9334-2c86193b401e",
+                                "type": "header",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "Bar",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "407ce876-6bb4-45c4-bba2-c54a26b26891",
+                                "type": "header",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "Baz",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "050fcd50-ead6-4959-9348-fa4d51fd8235",
+                                "type": "header",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "text": "Bat",
+                                        "spans": [],
+                                        "direction": "ltr"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Prismic.io have finally added support for tables in the content api:

https://prismic.io/docs/fields/table

https://prismic.io/updates/tables

This patch updates the fragment factory to parse this data and return `Fragment\Table` objects that can be sent to a serializer for rendering.