### PR TITLE
General Type Inference Improvements + Extended Link Information

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -11,23 +11,37 @@ use Prismic\Value\Translation;
 
 interface Document
 {
-    /** The document unique identifier */
+    /**
+     * The document unique identifier
+     *
+     * @return non-empty-string
+     */
     public function id(): string;
 
     /**
      * The unique user document identifier (Unique within a language and a type)
      *
      * It is possible for the uid to be null
+     *
+     * @return non-empty-string|null
      */
     public function uid(): string|null;
 
-    /** The document type */
+    /**
+     * The document type
+     *
+     * @return non-empty-string
+     */
     public function type(): string;
 
-    /** @return string[] */
+    /** @return list<non-empty-string> */
     public function tags(): iterable;
 
-    /** the document language code such as "en-gb" */
+    /**
+     * the document language code such as "en-gb"
+     *
+     * @return non-empty-string
+     */
     public function lang(): string;
 
     /** The date the document was first published */
@@ -36,7 +50,7 @@ interface Document
     /** The last time the document was changed */
     public function lastPublished(): DateTimeInterface;
 
-    /** @return Translation[] */
+    /** @return list<Translation> */
     public function translations(): iterable;
 
     /**
@@ -45,7 +59,7 @@ interface Document
     public function asLink(): DocumentLink;
 
     /**
-     * Return the value object containing all of the document content fragments
+     * Return the value object containing all the document content fragments
      */
     public function data(): DocumentData;
 }

--- a/src/Document/DocumentDataConsumer.php
+++ b/src/Document/DocumentDataConsumer.php
@@ -13,27 +13,31 @@ trait DocumentDataConsumer
 {
     private DocumentData $data;
 
+    /** @return non-empty-string */
     public function id(): string
     {
         return $this->data->id();
     }
 
+    /** @return non-empty-string|null */
     public function uid(): string|null
     {
         return $this->data->uid();
     }
 
+    /** @return non-empty-string */
     public function type(): string
     {
         return $this->data->type();
     }
 
-    /** @return string[] */
+    /** @return list<non-empty-string> */
     public function tags(): iterable
     {
         return $this->data->tags();
     }
 
+    /** @return non-empty-string */
     public function lang(): string
     {
         return $this->data->lang();
@@ -49,7 +53,7 @@ trait DocumentDataConsumer
         return $this->data->lastPublished();
     }
 
-    /** @return Translation[] */
+    /** @return list<Translation> */
     public function translations(): iterable
     {
         return $this->data->translations();

--- a/src/Document/Fragment/DocumentLink.php
+++ b/src/Document/Fragment/DocumentLink.php
@@ -4,37 +4,55 @@ declare(strict_types=1);
 
 namespace Prismic\Document\Fragment;
 
+use DateTimeImmutable;
 use Override;
 use Prismic\Document;
 use Prismic\Document\Fragment;
 use Prismic\Link;
+use Traversable;
 
-final class DocumentLink implements Fragment, Link
+use function array_filter;
+use function array_map;
+use function array_values;
+use function iterator_to_array;
+
+final readonly class DocumentLink implements Fragment, Link
 {
-    /** @var string[] */
+    /** @var list<non-empty-string> */
     private array $tags;
 
-    /** @param string[] $tags */
+    /**
+     * @param non-empty-string         $id
+     * @param non-empty-string|null    $uid
+     * @param non-empty-string         $type
+     * @param non-empty-string         $lang
+     * @param array<array-key, string> $tags
+     * @param non-empty-string|null    $slug
+     */
     private function __construct(
         private string $id,
         private string|null $uid,
         private string $type,
         private string $lang,
         private bool $isBroken,
-        iterable $tags,
+        array $tags,
+        private string|null $slug = null,
+        private DateTimeImmutable|null $firstPublicationDate = null,
+        private DateTimeImmutable|null $lastPublicationDate = null,
     ) {
-        $this->tags = [];
-        foreach ($tags as $tag) {
-            $this->addTag($tag);
-        }
+        $this->tags = array_values(array_filter(
+            $tags,
+            static fn (string $tag): bool => $tag !== '',
+        ));
     }
 
-    private function addTag(string $tag): void
-    {
-        $this->tags[] = $tag;
-    }
-
-    /** @param string[] $tags */
+    /**
+     * @param non-empty-string            $id
+     * @param non-empty-string|null       $uid
+     * @param non-empty-string            $type
+     * @param non-empty-string            $lang
+     * @param iterable<array-key, string> $tags
+     */
     public static function new(
         string $id,
         string|null $uid,
@@ -43,7 +61,44 @@ final class DocumentLink implements Fragment, Link
         bool $isBroken = false,
         iterable $tags = [],
     ): self {
+        $tags = $tags instanceof Traversable ? iterator_to_array($tags, false) : $tags;
+        $tags = array_values(array_map(static function (mixed $tag): string {
+            return $tag;
+        }, $tags));
+
         return new self($id, $uid, $type, $lang, $isBroken, $tags);
+    }
+
+    /**
+     * @param non-empty-string         $id
+     * @param non-empty-string|null    $uid
+     * @param non-empty-string         $type
+     * @param non-empty-string         $lang
+     * @param array<array-key, string> $tags
+     * @param non-empty-string|null    $slug
+     */
+    public static function withExtendedInformation(
+        string $id,
+        string|null $uid,
+        string $type,
+        string $lang,
+        bool $isBroken = false,
+        array $tags = [],
+        string|null $slug = null,
+        DateTimeImmutable|null $firstPublicationDate = null,
+        DateTimeImmutable|null $lastPublicationDate = null,
+    ): self {
+        return new self(
+            $id,
+            $uid,
+            $type,
+            $lang,
+            $isBroken,
+            $tags,
+            $slug,
+            $firstPublicationDate,
+            $lastPublicationDate,
+        );
     }
 
     public static function withDocument(Document $document): self
@@ -83,8 +138,8 @@ final class DocumentLink implements Fragment, Link
         return $this->isBroken;
     }
 
-    /** @return string[] */
-    public function tags(): iterable
+    /** @return list<string> */
+    public function tags(): array
     {
         return $this->tags;
     }
@@ -98,5 +153,21 @@ final class DocumentLink implements Fragment, Link
     public function isEmpty(): bool
     {
         return false;
+    }
+
+    public function firstPublished(): DateTimeImmutable|null
+    {
+        return $this->firstPublicationDate;
+    }
+
+    public function lastPublished(): DateTimeImmutable|null
+    {
+        return $this->lastPublicationDate;
+    }
+
+    /** @return non-empty-string|null */
+    public function slug(): string|null
+    {
+        return $this->slug;
     }
 }

--- a/src/Document/Fragment/Factory.php
+++ b/src/Document/Fragment/Factory.php
@@ -216,14 +216,35 @@ final class Factory
 
         if ($type === 'Document') {
             $isBroken = self::assertObjectPropertyIsBoolean($data, 'isBroken');
-            $lang = self::optionalStringProperty($data, 'lang');
+            $lang = self::optionalNonEmptyStringProperty($data, 'lang');
             // The language for broken document links is null in some situations
             $lang ??= '*';
 
+            $slug = self::optionalNonEmptyStringProperty($data, 'slug');
+            $first = self::optionalNonEmptyStringProperty($data, 'first_publication_date');
+            $last = self::optionalNonEmptyStringProperty($data, 'last_publication_date');
+
+            if ($first !== null && $last !== null) {
+                $first = self::assertObjectPropertyIsUtcDateTime($data, 'first_publication_date');
+                $last = self::assertObjectPropertyIsUtcDateTime($data, 'last_publication_date');
+
+                return DocumentLink::withExtendedInformation(
+                    self::assertObjectPropertyIsNonEmptyString($data, 'id'),
+                    self::optionalNonEmptyStringProperty($data, 'uid'),
+                    self::assertObjectPropertyIsNonEmptyString($data, 'type'),
+                    $lang,
+                    $isBroken,
+                    self::assertObjectPropertyAllString($data, 'tags'),
+                    $slug,
+                    $first,
+                    $last,
+                );
+            }
+
             return DocumentLink::new(
-                self::assertObjectPropertyIsString($data, 'id'),
-                self::optionalStringProperty($data, 'uid'),
-                self::assertObjectPropertyIsString($data, 'type'),
+                self::assertObjectPropertyIsNonEmptyString($data, 'id'),
+                self::optionalNonEmptyStringProperty($data, 'uid'),
+                self::assertObjectPropertyIsNonEmptyString($data, 'type'),
                 $lang,
                 $isBroken,
                 self::assertObjectPropertyAllString($data, 'tags'),

--- a/src/Value/DataAssertionBehaviour.php
+++ b/src/Value/DataAssertionBehaviour.php
@@ -114,11 +114,29 @@ trait DataAssertionBehaviour
         return $mixed;
     }
 
+    /** @return non-empty-string */
+    private static function assertNonEmptyString(mixed $mixed): string
+    {
+        if (! is_string($mixed) || $mixed === '') {
+            throw new UnexpectedValue('Expected a non-empty-string');
+        }
+
+        return $mixed;
+    }
+
     /** @return array<array-key, string> */
     private static function assertObjectPropertyAllString(object $object, string $property): array
     {
         return array_map(static function ($value): string {
             return self::assertString($value);
+        }, self::assertObjectPropertyIsArray($object, $property));
+    }
+
+    /** @return array<array-key, non-empty-string> */
+    private static function assertObjectPropertyAllNonEmptyString(object $object, string $property): array
+    {
+        return array_map(static function ($value): string {
+            return self::assertNonEmptyString($value);
         }, self::assertObjectPropertyIsArray($object, $property));
     }
 
@@ -140,7 +158,7 @@ trait DataAssertionBehaviour
         }
 
         $value = $object->{$property};
-        if (! $value) {
+        if ($value === null || $value === '') {
             return null;
         }
 

--- a/src/Value/DocumentData.php
+++ b/src/Value/DocumentData.php
@@ -16,20 +16,20 @@ use Prismic\Document\Fragment\Factory;
 use Prismic\Document\FragmentCollection;
 
 use function array_map;
+use function array_values;
 use function get_object_vars;
 
-final class DocumentData implements Document
+final readonly class DocumentData implements Document
 {
     use DataAssertionBehaviour;
 
-    /** @var string[] */
-    private array $tags;
-    /** @var Translation[] */
-    private array $translations;
-
     /**
-     * @param string[]      $tags
-     * @param Translation[] $translations
+     * @param non-empty-string       $id
+     * @param non-empty-string|null  $uid
+     * @param non-empty-string       $type
+     * @param non-empty-string       $lang
+     * @param list<non-empty-string> $tags
+     * @param list<Translation>      $translations
      */
     private function __construct(
         private string $id,
@@ -38,12 +38,10 @@ final class DocumentData implements Document
         private string $lang,
         private DateTimeImmutable $firstPublished,
         private DateTimeImmutable $lastPublished,
-        iterable $tags,
-        iterable $translations,
+        private array $tags,
+        private array $translations,
         private FragmentCollection $body,
     ) {
-        $this->setTags(...$tags);
-        $this->setTranslations(...$translations);
     }
 
     public static function factory(object $data): self
@@ -53,15 +51,15 @@ final class DocumentData implements Document
             return Factory::factory($value);
         }, get_object_vars($documentBody)));
 
-        $translations = array_map(static function (object $value): Translation {
+        $translations = array_values(array_map(static function (object $value): Translation {
             return Translation::factory($value);
-        }, self::assertObjectPropertyIsArray($data, 'alternate_languages'));
+        }, self::assertObjectPropertyIsArray($data, 'alternate_languages')));
 
         /**
          * In Preview mode, Document dates are nullified, FFS.
          */
         foreach (['first_publication_date', 'last_publication_date'] as $prop) {
-            if (isset($data->{$prop}) && $data->{$prop} !== null) {
+            if (isset($data->{$prop})) {
                 continue;
             }
 
@@ -70,13 +68,13 @@ final class DocumentData implements Document
         }
 
         return new self(
-            self::assertObjectPropertyIsString($data, 'id'),
-            self::optionalStringProperty($data, 'uid'),
-            self::assertObjectPropertyIsString($data, 'type'),
-            self::assertObjectPropertyIsString($data, 'lang'),
+            self::assertObjectPropertyIsNonEmptyString($data, 'id'),
+            self::optionalNonEmptyStringProperty($data, 'uid'),
+            self::assertObjectPropertyIsNonEmptyString($data, 'type'),
+            self::assertObjectPropertyIsNonEmptyString($data, 'lang'),
             self::assertObjectPropertyIsUtcDateTime($data, 'first_publication_date'),
             self::assertObjectPropertyIsUtcDateTime($data, 'last_publication_date'),
-            self::assertObjectPropertyAllString($data, 'tags'),
+            array_values(self::assertObjectPropertyAllNonEmptyString($data, 'tags')),
             $translations,
             $body,
         );
@@ -125,22 +123,12 @@ final class DocumentData implements Document
         return $this->lastPublished;
     }
 
-    private function setTags(string ...$tags): void
-    {
-        $this->tags = $tags;
-    }
-
     public function content(): FragmentCollection
     {
         return $this->body;
     }
 
-    private function setTranslations(Translation ...$translations): void
-    {
-        $this->translations = $translations;
-    }
-
-    /** @return Translation[] */
+    /** @inheritDoc */
     #[Override]
     public function translations(): iterable
     {

--- a/test/Unit/Document/Fragment/DocumentLinkTest.php
+++ b/test/Unit/Document/Fragment/DocumentLinkTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PrismicTest\Document\Fragment;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use PHPUnit\Framework\Attributes\Depends;
 use Prismic\Document\Fragment\DocumentLink;
 use PrismicTest\Framework\TestCase;
@@ -81,5 +83,56 @@ final class DocumentLinkTest extends TestCase
     {
         $this->assertContainsEquals('a', $link->tags());
         $this->assertContainsEquals('b', $link->tags());
+    }
+
+    public function testExtendedInformation(): DocumentLink
+    {
+        $firstPublicationDate = DateTimeImmutable::createFromFormat('!Y-m-d', '2020-01-01', new DateTimeZone('UTC'));
+        $lastPublicationDate = DateTimeImmutable::createFromFormat('!Y-m-d', '2020-02-02', new DateTimeZone('UTC'));
+
+        self::assertNotFalse($firstPublicationDate);
+        self::assertNotFalse($lastPublicationDate);
+
+        return DocumentLink::withExtendedInformation(
+            'some-id',
+            'some-uid',
+            'some-type',
+            'en-gb',
+            false,
+            ['foo', 'bar'],
+            'some-slug',
+            $firstPublicationDate,
+            $lastPublicationDate,
+        );
+    }
+
+    #[Depends('testConstructor')]
+    #[Depends('testExtendedInformation')]
+    public function testThatLinksCanReportFirstPublicationDate(DocumentLink $link, DocumentLink $extended): void
+    {
+        self::assertNull($link->firstPublished());
+
+        $date = $extended->firstPublished();
+        self::assertNotNull($date);
+        self::assertSame('2020-01-01', $date->format('Y-m-d'));
+    }
+
+    #[Depends('testConstructor')]
+    #[Depends('testExtendedInformation')]
+    public function testThatLinksCanReportLastPublicationDate(DocumentLink $link, DocumentLink $extended): void
+    {
+        self::assertNull($link->lastPublished());
+
+        $date = $extended->lastPublished();
+        self::assertNotNull($date);
+        self::assertSame('2020-02-02', $date->format('Y-m-d'));
+    }
+
+    #[Depends('testConstructor')]
+    #[Depends('testExtendedInformation')]
+    public function testThatLinksCanBeAssociatedWithASlug(DocumentLink $link, DocumentLink $extended): void
+    {
+        self::assertNull($link->slug());
+        self::assertSame('some-slug', $extended->slug());
     }
 }

--- a/test/Unit/Document/Fragment/FactoryTest.php
+++ b/test/Unit/Document/Fragment/FactoryTest.php
@@ -14,8 +14,10 @@ use Prismic\Document\Fragment\EmptyFragment;
 use Prismic\Document\Fragment\Factory;
 use Prismic\Document\Fragment\GeoPoint;
 use Prismic\Document\Fragment\Image;
+use Prismic\Document\Fragment\ImageLink;
 use Prismic\Document\Fragment\Number;
 use Prismic\Document\Fragment\StringFragment;
+use Prismic\Document\Fragment\WebLink;
 use Prismic\Document\FragmentCollection;
 use Prismic\Exception\InvalidArgument;
 use Prismic\Exception\UnexpectedValue;
@@ -345,5 +347,26 @@ final class FactoryTest extends TestCase
 
         $table = $document->content()->get('table');
         self::assertInstanceOf(Fragment\Table::class, $table);
+    }
+
+    public function testGenericLinkParsing(): void
+    {
+        $json = file_get_contents(__DIR__ . '/../../../fixture/links.json');
+        self::assertNotFalse($json);
+        $document = DocumentData::factory(Json::decodeObject($json));
+
+        $doc = $document->content()->get('doc-link');
+        self::assertInstanceOf(DocumentLink::class, $doc);
+        self::assertNull($doc->firstPublished());
+
+        $extended = $document->content()->get('doc-link-extended');
+        self::assertInstanceOf(DocumentLink::class, $extended);
+        self::assertNotNull($extended->firstPublished());
+
+        $web = $document->content()->get('web-link');
+        self::assertInstanceOf(WebLink::class, $web);
+
+        $image = $document->content()->get('image-link');
+        self::assertInstanceOf(ImageLink::class, $image);
     }
 }

--- a/test/fixture/links.json
+++ b/test/fixture/links.json
@@ -1,0 +1,51 @@
+{
+    "id": "document-id",
+    "uid": "document-uid",
+    "type": "custom-type",
+    "href": "foo",
+    "tags": [],
+    "first_publication_date": "2020-01-01T01:23:45+0000",
+    "last_publication_date": "2020-01-02T01:23:45+0000",
+    "slugs": [],
+    "linked_documents": [],
+    "lang": "en-gb",
+    "alternate_languages": [],
+    "data": {
+        "doc-link": {
+            "id": "some-id",
+            "type": "page",
+            "tags": [],
+            "lang": "en-gb",
+            "slug": "homepage",
+            "uid": "home",
+            "link_type": "Document",
+            "isBroken": false
+        },
+        "doc-link-extended": {
+            "id": "some-id",
+            "type": "page",
+            "tags": [],
+            "lang": "en-gb",
+            "slug": "homepage",
+            "first_publication_date": "2025-03-26T15:43:27+0000",
+            "last_publication_date": "2025-03-26T15:43:27+0000",
+            "uid": "home",
+            "link_type": "Document",
+            "isBroken": false
+        },
+        "web-link": {
+            "link_type": "Web",
+            "url": "https://example.com"
+        },
+        "image-link": {
+            "link_type": "Media",
+            "kind": "image",
+            "id": "Z_Z2UHdAxsiBwfKb",
+            "url": "https://images.prismic.io/some-repo/whatever.png",
+            "name": "Animal.jpg",
+            "size": "94188",
+            "width": "1248",
+            "height": "702"
+        }
+    }
+}


### PR DESCRIPTION
Document Links now contain the first/last publication date of the target document. This patch add methods to the document link fragment to expose these values.