### PR TITLE
Add support for new-style text links

### DIFF
--- a/src/Document/Fragment/Factory.php
+++ b/src/Document/Fragment/Factory.php
@@ -186,32 +186,39 @@ final class Factory
     private static function linkFactory(object $data): Link
     {
         $type = self::assertObjectPropertyIsString($data, 'link_type');
+        $text = self::optionalNonEmptyStringProperty($data, 'text');
 
         if ($type === 'Web') {
-            return WebLink::new(
+            $link = WebLink::new(
                 self::assertObjectPropertyIsString($data, 'url'),
                 self::optionalStringProperty($data, 'target'),
             );
+
+            return $text === null ? $link : TextLink::new($text, $link);
         }
 
         $kind = self::optionalStringProperty($data, 'kind');
 
         if ($type === 'Media' && $kind === 'image') {
-            return ImageLink::new(
+            $link = ImageLink::new(
                 self::assertObjectPropertyIsString($data, 'url'),
                 self::assertObjectPropertyIsString($data, 'name'),
                 self::assertObjectPropertyIsIntegerish($data, 'size'),
                 self::assertObjectPropertyIsIntegerish($data, 'width'),
                 self::assertObjectPropertyIsIntegerish($data, 'height'),
             );
+
+            return $text === null ? $link : TextLink::new($text, $link);
         }
 
         if ($type === 'Media') {
-            return MediaLink::new(
+            $link = MediaLink::new(
                 self::assertObjectPropertyIsString($data, 'url'),
                 self::assertObjectPropertyIsString($data, 'name'),
                 self::assertObjectPropertyIsIntegerish($data, 'size'),
             );
+
+            return $text === null ? $link : TextLink::new($text, $link);
         }
 
         if ($type === 'Document') {
@@ -228,7 +235,7 @@ final class Factory
                 $first = self::assertObjectPropertyIsUtcDateTime($data, 'first_publication_date');
                 $last = self::assertObjectPropertyIsUtcDateTime($data, 'last_publication_date');
 
-                return DocumentLink::withExtendedInformation(
+                $link = DocumentLink::withExtendedInformation(
                     self::assertObjectPropertyIsNonEmptyString($data, 'id'),
                     self::optionalNonEmptyStringProperty($data, 'uid'),
                     self::assertObjectPropertyIsNonEmptyString($data, 'type'),
@@ -239,9 +246,11 @@ final class Factory
                     $first,
                     $last,
                 );
+
+                return $text === null ? $link : TextLink::new($text, $link);
             }
 
-            return DocumentLink::new(
+            $link = DocumentLink::new(
                 self::assertObjectPropertyIsNonEmptyString($data, 'id'),
                 self::optionalNonEmptyStringProperty($data, 'uid'),
                 self::assertObjectPropertyIsNonEmptyString($data, 'type'),
@@ -249,6 +258,8 @@ final class Factory
                 $isBroken,
                 self::assertObjectPropertyAllString($data, 'tags'),
             );
+
+            return $text === null ? $link : TextLink::new($text, $link);
         }
 
         throw InvalidArgument::unknownLinkType($type, $data);

--- a/src/Document/Fragment/TextLink.php
+++ b/src/Document/Fragment/TextLink.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prismic\Document\Fragment;
+
+use Override;
+use Prismic\Document\Fragment;
+use Prismic\Link;
+
+final readonly class TextLink implements Fragment, Link
+{
+    /** @param non-empty-string $text */
+    private function __construct(
+        public string $text,
+        public Link $link,
+    ) {
+    }
+
+    /** @param non-empty-string $text */
+    public static function new(
+        string $text,
+        Link $link,
+    ): self {
+        return new self($text, $link);
+    }
+
+    #[Override]
+    public function isEmpty(): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function __toString(): string
+    {
+        return (string) $this->link;
+    }
+}

--- a/src/Serializer/HtmlSerializer.php
+++ b/src/Serializer/HtmlSerializer.php
@@ -28,6 +28,7 @@ use Prismic\Document\Fragment\Table;
 use Prismic\Document\Fragment\TableCell;
 use Prismic\Document\Fragment\TableRow;
 use Prismic\Document\Fragment\TextElement;
+use Prismic\Document\Fragment\TextLink;
 use Prismic\Document\Fragment\WebLink;
 use Prismic\Document\FragmentCollection;
 use Prismic\Exception\UnexpectedValue;
@@ -139,6 +140,9 @@ class HtmlSerializer
             case Image::class:
                 return $this->image($fragment);
 
+            case TextLink::class:
+                return $this->textLink($fragment);
+
             case WebLink::class:
             case DocumentLink::class:
             case ImageLink::class:
@@ -229,6 +233,14 @@ class HtmlSerializer
             '%s%s</a>',
             $openTag,
             $wraps ?? (string) $link,
+        );
+    }
+
+    private function textLink(TextLink $fragment): string
+    {
+        return $this->link(
+            $fragment->link,
+            $this->escaper->escapeHtml($fragment->text),
         );
     }
 

--- a/test/Unit/Document/Fragment/FactoryTest.php
+++ b/test/Unit/Document/Fragment/FactoryTest.php
@@ -17,6 +17,7 @@ use Prismic\Document\Fragment\Image;
 use Prismic\Document\Fragment\ImageLink;
 use Prismic\Document\Fragment\Number;
 use Prismic\Document\Fragment\StringFragment;
+use Prismic\Document\Fragment\TextLink;
 use Prismic\Document\Fragment\WebLink;
 use Prismic\Document\FragmentCollection;
 use Prismic\Exception\InvalidArgument;
@@ -27,6 +28,7 @@ use PrismicTest\Framework\TestCase;
 
 use function assert;
 use function file_get_contents;
+use function iterator_to_array;
 
 final class FactoryTest extends TestCase
 {
@@ -368,5 +370,35 @@ final class FactoryTest extends TestCase
 
         $image = $document->content()->get('image-link');
         self::assertInstanceOf(ImageLink::class, $image);
+    }
+
+    public function testTextLinksAreReturnedWhenTheTextPropertyIsPresentAndNonEmpty(): void
+    {
+        $json = file_get_contents(__DIR__ . '/../../../fixture/links.json');
+        self::assertNotFalse($json);
+        $document = DocumentData::factory(Json::decodeObject($json));
+
+        $collection = $document->content()->get('text-link-list');
+        self::assertInstanceOf(FragmentCollection::class, $collection);
+
+        $links = iterator_to_array($collection, false);
+        self::assertCount(4, $links);
+
+        /** @psalm-suppress PossiblyUndefinedArrayOffset */
+        [$web, $media, $doc, $bare] = $links;
+
+        self::assertInstanceOf(TextLink::class, $web);
+        self::assertSame('Link 1', $web->text);
+        self::assertInstanceOf(WebLink::class, $web->link);
+
+        self::assertInstanceOf(TextLink::class, $media);
+        self::assertSame('Link 2', $media->text);
+        self::assertInstanceOf(ImageLink::class, $media->link);
+
+        self::assertInstanceOf(TextLink::class, $doc);
+        self::assertSame('Link 3', $doc->text);
+        self::assertInstanceOf(DocumentLink::class, $doc->link);
+
+        self::assertInstanceOf(WebLink::class, $bare);
     }
 }

--- a/test/Unit/Document/Fragment/TextLinkTest.php
+++ b/test/Unit/Document/Fragment/TextLinkTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrismicTest\Document\Fragment;
+
+use PHPUnit\Framework\TestCase;
+use Prismic\Document\Fragment\TextLink;
+use Prismic\Document\Fragment\WebLink;
+
+final class TextLinkTest extends TestCase
+{
+    public function testTextLinksAreNotConsideredEmpty(): void
+    {
+        $link = TextLink::new(
+            'Foo',
+            WebLink::new('foo', null),
+        );
+
+        self::assertFalse($link->isEmpty());
+    }
+
+    public function testStringRepresentationIsSameAsTheUnderlyingLink(): void
+    {
+        $link = TextLink::new(
+            'Foo',
+            WebLink::new('foo', null),
+        );
+
+        self::assertSame($link->link->__toString(), $link->__toString());
+    }
+}

--- a/test/Unit/Serializer/HtmlSerializerTest.php
+++ b/test/Unit/Serializer/HtmlSerializerTest.php
@@ -10,6 +10,7 @@ use Prismic\Document\Fragment;
 use Prismic\Document\Fragment\Factory;
 use Prismic\Document\Fragment\OrderedList;
 use Prismic\Document\Fragment\RichText;
+use Prismic\Document\Fragment\TextLink;
 use Prismic\Document\Fragment\UnorderedList;
 use Prismic\Document\FragmentCollection;
 use Prismic\Exception\UnexpectedValue;
@@ -20,6 +21,7 @@ use PrismicTest\Framework\TestCase;
 use PrismicTest\TestLinkResolver;
 
 use function assert;
+use function iterator_to_array;
 
 final class HtmlSerializerTest extends TestCase
 {
@@ -354,6 +356,25 @@ final class HtmlSerializerTest extends TestCase
         self::assertSame(
             $expect,
             $this->serializer->__invoke($table),
+        );
+    }
+
+    public function testTextLinkRendering(): void
+    {
+        $document = DocumentData::factory(
+            Json::decodeObject(
+                $this->jsonFixtureByFileName('links.json'),
+            ),
+        );
+
+        $textLinks = $document->content()->get('text-link-list');
+        self::assertInstanceOf(FragmentCollection::class, $textLinks);
+        $link = iterator_to_array($textLinks, false)[0];
+        self::assertInstanceOf(TextLink::class, $link);
+
+        self::assertSame(
+            '<a href="https://www.example.com">Link 1</a>',
+            $this->serializer->__invoke($link),
         );
     }
 }

--- a/test/fixture/links.json
+++ b/test/fixture/links.json
@@ -46,6 +46,96 @@
             "size": "94188",
             "width": "1248",
             "height": "702"
-        }
+        },
+        "text-link-list": [
+            {
+                "link_type": "Web",
+                "key": "64b9c0eb-003c-4cad-9b68-b955d75a844c",
+                "url": "https://www.example.com",
+                "text": "Link 1"
+            },
+            {
+                "link_type": "Media",
+                "key": "858939cd-44dd-4d25-b5ce-2c741e7bf6c5",
+                "kind": "image",
+                "id": "some-id",
+                "url": "https://images.prismic.io/some-repo/whatever.png",
+                "name": "Animal.jpg",
+                "size": "94188",
+                "width": "1248",
+                "height": "702",
+                "text": "Link 2"
+            },
+            {
+                "id": "some-id",
+                "type": "page",
+                "tags": [],
+                "lang": "en-gb",
+                "slug": "homepage",
+                "first_publication_date": "2025-03-26T15:43:27+0000",
+                "last_publication_date": "2025-03-26T15:43:27+0000",
+                "uid": "home",
+                "link_type": "Document",
+                "key": "3dd9a967-3199-4ec7-9a22-88a386ca718c",
+                "isBroken": false,
+                "text": "Link 3"
+            },
+            {
+                "link_type": "Web",
+                "key": "link-without-text",
+                "url": "https://www.example.com"
+            }
+        ],
+        "variants": [
+            {
+                "link_type": "Web",
+                "key": "64b9c0eb-003c-4cad-9b68-b955d75a844c",
+                "url": "https://www.example.com",
+                "text": "Link 1",
+                "variant": "Secondary"
+            },
+            {
+                "link_type": "Media",
+                "key": "858939cd-44dd-4d25-b5ce-2c741e7bf6c5",
+                "kind": "image",
+                "id": "some-id",
+                "url": "https://some-image",
+                "name": "Animal.jpg",
+                "size": "94188",
+                "width": "1248",
+                "height": "702",
+                "text": "Link 2",
+                "variant": "Primary"
+            },
+            {
+                "id": "some-id",
+                "type": "page",
+                "tags": [],
+                "lang": "en-gb",
+                "slug": "homepage",
+                "first_publication_date": "2025-03-26T15:43:27+0000",
+                "last_publication_date": "2025-03-26T15:43:27+0000",
+                "uid": "home",
+                "link_type": "Document",
+                "key": "3dd9a967-3199-4ec7-9a22-88a386ca718c",
+                "isBroken": false,
+                "text": "Link 3",
+                "variant": "Secondary"
+            },
+            {
+                "link_type": "Web",
+                "key": "8a8f6913-7a75-4b38-b98f-6e3c9b2b7521",
+                "url": "https://www.example.com",
+                "variant": "Primary"
+            },
+            {
+                "link_type": "Web",
+                "key": "e2896f27-4f23-4efa-9b52-e5fb83063141",
+                "url": "https://www.example.com",
+                "target": "_blank",
+                "text": "With Blank",
+                "variant": "Primary"
+            }
+        ]
     }
 }


### PR DESCRIPTION
Prismic released changes to the link field back in October 2024 ish:

https://prismic.io/updates/link-field

This patch adds support for links with "integrated" text anchors with a new fragment type of `Prismic\Fragment\TextLink`.

The shipped HTML serializer has been updated to suit, but custom serializers will need to be changed to render this new fragment type