### PR TITLE
Add support for "Link Variants"

### DIFF
--- a/src/Document/Fragment/DocumentLink.php
+++ b/src/Document/Fragment/DocumentLink.php
@@ -9,6 +9,7 @@ use Override;
 use Prismic\Document;
 use Prismic\Document\Fragment;
 use Prismic\Link;
+use Prismic\LinkVariant;
 use Traversable;
 
 use function array_filter;
@@ -16,7 +17,7 @@ use function array_map;
 use function array_values;
 use function iterator_to_array;
 
-final readonly class DocumentLink implements Fragment, Link
+final readonly class DocumentLink implements Fragment, Link, LinkVariant
 {
     /** @var list<non-empty-string> */
     private array $tags;
@@ -28,6 +29,7 @@ final readonly class DocumentLink implements Fragment, Link
      * @param non-empty-string         $lang
      * @param array<array-key, string> $tags
      * @param non-empty-string|null    $slug
+     * @param non-empty-string|null    $variant
      */
     private function __construct(
         private string $id,
@@ -39,6 +41,7 @@ final readonly class DocumentLink implements Fragment, Link
         private string|null $slug = null,
         private DateTimeImmutable|null $firstPublicationDate = null,
         private DateTimeImmutable|null $lastPublicationDate = null,
+        private string|null $variant = null,
     ) {
         $this->tags = array_values(array_filter(
             $tags,
@@ -52,6 +55,7 @@ final readonly class DocumentLink implements Fragment, Link
      * @param non-empty-string            $type
      * @param non-empty-string            $lang
      * @param iterable<array-key, string> $tags
+     * @param non-empty-string|null       $variant
      */
     public static function new(
         string $id,
@@ -60,13 +64,14 @@ final readonly class DocumentLink implements Fragment, Link
         string $lang,
         bool $isBroken = false,
         iterable $tags = [],
+        string|null $variant = null,
     ): self {
         $tags = $tags instanceof Traversable ? iterator_to_array($tags, false) : $tags;
         $tags = array_values(array_map(static function (mixed $tag): string {
             return $tag;
         }, $tags));
 
-        return new self($id, $uid, $type, $lang, $isBroken, $tags);
+        return new self($id, $uid, $type, $lang, $isBroken, $tags, null, null, null, $variant);
     }
 
     /**
@@ -76,6 +81,7 @@ final readonly class DocumentLink implements Fragment, Link
      * @param non-empty-string         $lang
      * @param array<array-key, string> $tags
      * @param non-empty-string|null    $slug
+     * @param non-empty-string|null    $variant
      */
     public static function withExtendedInformation(
         string $id,
@@ -87,6 +93,7 @@ final readonly class DocumentLink implements Fragment, Link
         string|null $slug = null,
         DateTimeImmutable|null $firstPublicationDate = null,
         DateTimeImmutable|null $lastPublicationDate = null,
+        string|null $variant = null,
     ): self {
         return new self(
             $id,
@@ -98,6 +105,7 @@ final readonly class DocumentLink implements Fragment, Link
             $slug,
             $firstPublicationDate,
             $lastPublicationDate,
+            $variant,
         );
     }
 
@@ -169,5 +177,12 @@ final readonly class DocumentLink implements Fragment, Link
     public function slug(): string|null
     {
         return $this->slug;
+    }
+
+    /** @return non-empty-string|null */
+    #[Override]
+    public function variant(): string|null
+    {
+        return $this->variant;
     }
 }

--- a/src/Document/Fragment/Factory.php
+++ b/src/Document/Fragment/Factory.php
@@ -187,11 +187,13 @@ final class Factory
     {
         $type = self::assertObjectPropertyIsString($data, 'link_type');
         $text = self::optionalNonEmptyStringProperty($data, 'text');
+        $variant = self::optionalNonEmptyStringProperty($data, 'variant');
 
         if ($type === 'Web') {
             $link = WebLink::new(
                 self::assertObjectPropertyIsString($data, 'url'),
                 self::optionalStringProperty($data, 'target'),
+                $variant,
             );
 
             return $text === null ? $link : TextLink::new($text, $link);
@@ -206,6 +208,7 @@ final class Factory
                 self::assertObjectPropertyIsIntegerish($data, 'size'),
                 self::assertObjectPropertyIsIntegerish($data, 'width'),
                 self::assertObjectPropertyIsIntegerish($data, 'height'),
+                $variant,
             );
 
             return $text === null ? $link : TextLink::new($text, $link);
@@ -216,6 +219,7 @@ final class Factory
                 self::assertObjectPropertyIsString($data, 'url'),
                 self::assertObjectPropertyIsString($data, 'name'),
                 self::assertObjectPropertyIsIntegerish($data, 'size'),
+                $variant,
             );
 
             return $text === null ? $link : TextLink::new($text, $link);
@@ -245,6 +249,7 @@ final class Factory
                     $slug,
                     $first,
                     $last,
+                    $variant,
                 );
 
                 return $text === null ? $link : TextLink::new($text, $link);
@@ -257,6 +262,7 @@ final class Factory
                 $lang,
                 $isBroken,
                 self::assertObjectPropertyAllString($data, 'tags'),
+                $variant,
             );
 
             return $text === null ? $link : TextLink::new($text, $link);

--- a/src/Document/Fragment/ImageLink.php
+++ b/src/Document/Fragment/ImageLink.php
@@ -6,27 +6,32 @@ namespace Prismic\Document\Fragment;
 
 use Override;
 use Prismic\Document\Fragment;
+use Prismic\LinkVariant;
 use Prismic\UrlLink;
 
-final class ImageLink implements Fragment, UrlLink
+final readonly class ImageLink implements Fragment, UrlLink, LinkVariant
 {
+    /** @param non-empty-string|null $variant */
     private function __construct(
         private string $url,
         private string $fileName,
         private int $fileSize,
         private int $width,
         private int $height,
+        private string|null $variant,
     ) {
     }
 
+    /** @param non-empty-string|null $variant */
     public static function new(
         string $url,
         string $fileName,
         int $fileSize,
         int $width,
         int $height,
+        string|null $variant = null,
     ): self {
-        return new self($url, $fileName, $fileSize, $width, $height);
+        return new self($url, $fileName, $fileSize, $width, $height, $variant);
     }
 
     #[Override]
@@ -64,5 +69,12 @@ final class ImageLink implements Fragment, UrlLink
     public function isEmpty(): bool
     {
         return false;
+    }
+
+    /** @return non-empty-string|null */
+    #[Override]
+    public function variant(): string|null
+    {
+        return $this->variant;
     }
 }

--- a/src/Document/Fragment/MediaLink.php
+++ b/src/Document/Fragment/MediaLink.php
@@ -6,23 +6,28 @@ namespace Prismic\Document\Fragment;
 
 use Override;
 use Prismic\Document\Fragment;
+use Prismic\LinkVariant;
 use Prismic\UrlLink;
 
-final class MediaLink implements Fragment, UrlLink
+final readonly class MediaLink implements Fragment, UrlLink, LinkVariant
 {
+    /** @param non-empty-string|null $variant */
     private function __construct(
         private string $url,
         private string $fileName,
         private int $fileSize,
+        private string|null $variant,
     ) {
     }
 
+    /** @param non-empty-string|null $variant */
     public static function new(
         string $url,
         string $fileName,
         int $fileSize,
+        string|null $variant = null,
     ): self {
-        return new self($url, $fileName, $fileSize);
+        return new self($url, $fileName, $fileSize, $variant);
     }
 
     #[Override]
@@ -50,5 +55,12 @@ final class MediaLink implements Fragment, UrlLink
     public function isEmpty(): bool
     {
         return false;
+    }
+
+    /** @return non-empty-string|null */
+    #[Override]
+    public function variant(): string|null
+    {
+        return $this->variant;
     }
 }

--- a/src/Document/Fragment/WebLink.php
+++ b/src/Document/Fragment/WebLink.php
@@ -6,19 +6,26 @@ namespace Prismic\Document\Fragment;
 
 use Override;
 use Prismic\Document\Fragment;
+use Prismic\LinkVariant;
 use Prismic\UrlLink;
 
-final class WebLink implements Fragment, UrlLink
+final readonly class WebLink implements Fragment, UrlLink, LinkVariant
 {
+    /** @param non-empty-string|null $variant */
     private function __construct(
         private string $url,
         private string|null $target,
+        private string|null $variant,
     ) {
     }
 
-    public static function new(string $url, string|null $target): self
-    {
-        return new self($url, $target);
+    /** @param non-empty-string|null $variant */
+    public static function new(
+        string $url,
+        string|null $target,
+        string|null $variant = null,
+    ): self {
+        return new self($url, $target, $variant);
     }
 
     #[Override]
@@ -41,5 +48,12 @@ final class WebLink implements Fragment, UrlLink
     public function isEmpty(): bool
     {
         return false;
+    }
+
+    /** @return non-empty-string|null */
+    #[Override]
+    public function variant(): string|null
+    {
+        return $this->variant;
     }
 }

--- a/src/LinkVariant.php
+++ b/src/LinkVariant.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prismic;
+
+interface LinkVariant
+{
+    /** @return non-empty-string|null */
+    public function variant(): string|null;
+}

--- a/src/Serializer/HtmlSerializer.php
+++ b/src/Serializer/HtmlSerializer.php
@@ -34,6 +34,7 @@ use Prismic\Document\FragmentCollection;
 use Prismic\Exception\UnexpectedValue;
 use Prismic\Link;
 use Prismic\LinkResolver;
+use Prismic\LinkVariant;
 
 use function array_filter;
 use function array_keys;
@@ -217,6 +218,7 @@ class HtmlSerializer
         $attributes = array_filter([
             'href' => $url,
             'target' => $link instanceof WebLink ? $link->target() : null,
+            'class' => $link instanceof LinkVariant ? $link->variant() : null,
         ]);
 
         return sprintf('<a%s>', $this->htmlAttributes($attributes));

--- a/test/Unit/Document/Fragment/FactoryTest.php
+++ b/test/Unit/Document/Fragment/FactoryTest.php
@@ -15,6 +15,7 @@ use Prismic\Document\Fragment\Factory;
 use Prismic\Document\Fragment\GeoPoint;
 use Prismic\Document\Fragment\Image;
 use Prismic\Document\Fragment\ImageLink;
+use Prismic\Document\Fragment\MediaLink;
 use Prismic\Document\Fragment\Number;
 use Prismic\Document\Fragment\StringFragment;
 use Prismic\Document\Fragment\TextLink;
@@ -400,5 +401,40 @@ final class FactoryTest extends TestCase
         self::assertInstanceOf(DocumentLink::class, $doc->link);
 
         self::assertInstanceOf(WebLink::class, $bare);
+    }
+
+    public function testLinksWithVariantsHaveTheExpectedValues(): void
+    {
+        $json = file_get_contents(__DIR__ . '/../../../fixture/links.json');
+        self::assertNotFalse($json);
+        $document = DocumentData::factory(Json::decodeObject($json));
+
+        $collection = $document->content()->get('variants');
+        self::assertInstanceOf(FragmentCollection::class, $collection);
+
+        $links = iterator_to_array($collection, false);
+        self::assertCount(5, $links);
+
+        /** @psalm-suppress PossiblyUndefinedArrayOffset */
+        [$web, $image, $doc, $bare, $media] = $links;
+
+        self::assertInstanceOf(TextLink::class, $web);
+        self::assertInstanceOf(WebLink::class, $web->link);
+        self::assertSame('Secondary', $web->link->variant());
+
+        self::assertInstanceOf(TextLink::class, $image);
+        self::assertInstanceOf(ImageLink::class, $image->link);
+        self::assertSame('Primary', $image->link->variant());
+
+        self::assertInstanceOf(TextLink::class, $doc);
+        self::assertInstanceOf(DocumentLink::class, $doc->link);
+        self::assertSame('Secondary', $doc->link->variant());
+
+        self::assertInstanceOf(WebLink::class, $bare);
+        self::assertSame('Primary', $bare->variant());
+
+        self::assertInstanceOf(TextLink::class, $media);
+        self::assertInstanceOf(MediaLink::class, $media->link);
+        self::assertSame('Primary', $media->link->variant());
     }
 }

--- a/test/Unit/Serializer/HtmlSerializerTest.php
+++ b/test/Unit/Serializer/HtmlSerializerTest.php
@@ -377,4 +377,23 @@ final class HtmlSerializerTest extends TestCase
             $this->serializer->__invoke($link),
         );
     }
+
+    public function testLinkVariantsAreAddedAsCSSClasses(): void
+    {
+        $document = DocumentData::factory(
+            Json::decodeObject(
+                $this->jsonFixtureByFileName('links.json'),
+            ),
+        );
+
+        $textLinks = $document->content()->get('variants');
+        self::assertInstanceOf(FragmentCollection::class, $textLinks);
+        $link = iterator_to_array($textLinks, false)[0];
+        self::assertInstanceOf(TextLink::class, $link);
+
+        self::assertSame(
+            '<a href="https://www.example.com" class="Secondary">Link 1</a>',
+            $this->serializer->__invoke($link),
+        );
+    }
 }

--- a/test/fixture/links.json
+++ b/test/fixture/links.json
@@ -129,9 +129,11 @@
                 "variant": "Primary"
             },
             {
-                "link_type": "Web",
+                "link_type": "Media",
                 "key": "e2896f27-4f23-4efa-9b52-e5fb83063141",
                 "url": "https://www.example.com",
+                "name": "bar",
+                "size": 123456,
                 "target": "_blank",
                 "text": "With Blank",
                 "variant": "Primary"


### PR DESCRIPTION
Prismic released changes to the link field back in October 2024 ish:

https://prismic.io/updates/link-field

This patch adds support for "variants" that will typically be applied as CSS classes to links.

This is what the shipped serializer has done.