### PR TITLE
Fix: Crashes for Unlinked Text Links

### DIFF
--- a/src/Document/Fragment/Factory.php
+++ b/src/Document/Fragment/Factory.php
@@ -179,19 +179,29 @@ final class Factory
             self::optionalStringProperty($data, 'alt'),
             self::optionalStringProperty($data, 'copyright'),
             $views,
-            $linkTo,
+            $linkTo instanceof Link ? $linkTo : null,
         );
     }
 
-    private static function linkFactory(object $data): Link
+    private static function linkFactory(object $data): Fragment
     {
         $type = self::assertObjectPropertyIsString($data, 'link_type');
         $text = self::optionalNonEmptyStringProperty($data, 'text');
         $variant = self::optionalNonEmptyStringProperty($data, 'variant');
+        $url = self::optionalNonEmptyStringProperty($data, 'url');
+
+        if ($type === 'Any') {
+            // This is probably a text link where the user has added some text, but not linked to anything
+            return $text === null ? new EmptyFragment() : StringFragment::new($text);
+        }
 
         if ($type === 'Web') {
+            if ($url === null) {
+                return $text === null ? new EmptyFragment() : StringFragment::new($text);
+            }
+
             $link = WebLink::new(
-                self::assertObjectPropertyIsString($data, 'url'),
+                $url,
                 self::optionalStringProperty($data, 'target'),
                 $variant,
             );
@@ -202,8 +212,12 @@ final class Factory
         $kind = self::optionalStringProperty($data, 'kind');
 
         if ($type === 'Media' && $kind === 'image') {
+            if ($url === null) {
+                return $text === null ? new EmptyFragment() : StringFragment::new($text);
+            }
+
             $link = ImageLink::new(
-                self::assertObjectPropertyIsString($data, 'url'),
+                $url,
                 self::assertObjectPropertyIsString($data, 'name'),
                 self::assertObjectPropertyIsIntegerish($data, 'size'),
                 self::assertObjectPropertyIsIntegerish($data, 'width'),
@@ -215,8 +229,12 @@ final class Factory
         }
 
         if ($type === 'Media') {
+            if ($url === null) {
+                return $text === null ? new EmptyFragment() : StringFragment::new($text);
+            }
+
             $link = MediaLink::new(
-                self::assertObjectPropertyIsString($data, 'url'),
+                $url,
                 self::assertObjectPropertyIsString($data, 'name'),
                 self::assertObjectPropertyIsIntegerish($data, 'size'),
                 $variant,
@@ -226,6 +244,12 @@ final class Factory
         }
 
         if ($type === 'Document') {
+            $id = self::optionalNonEmptyStringProperty($data, 'id');
+            if ($id === null) {
+                // This is likely a text link that has not been linked anywhere
+                return $text === null ? new EmptyFragment() : StringFragment::new($text);
+            }
+
             $isBroken = self::assertObjectPropertyIsBoolean($data, 'isBroken');
             $lang = self::optionalNonEmptyStringProperty($data, 'lang');
             // The language for broken document links is null in some situations
@@ -256,7 +280,7 @@ final class Factory
             }
 
             $link = DocumentLink::new(
-                self::assertObjectPropertyIsNonEmptyString($data, 'id'),
+                $id,
                 self::optionalNonEmptyStringProperty($data, 'uid'),
                 self::assertObjectPropertyIsNonEmptyString($data, 'type'),
                 $lang,
@@ -357,7 +381,7 @@ final class Factory
             self::assertObjectPropertyIsInteger($data, 'start'),
             self::assertObjectPropertyIsInteger($data, 'end'),
             $label,
-            $link,
+            $link instanceof Link ? $link : null,
         );
     }
 

--- a/test/Unit/Document/Fragment/FactoryTest.php
+++ b/test/Unit/Document/Fragment/FactoryTest.php
@@ -28,6 +28,7 @@ use Prismic\Value\DocumentData;
 use PrismicTest\Framework\TestCase;
 
 use function assert;
+use function count;
 use function file_get_contents;
 use function iterator_to_array;
 
@@ -383,7 +384,7 @@ final class FactoryTest extends TestCase
         self::assertInstanceOf(FragmentCollection::class, $collection);
 
         $links = iterator_to_array($collection, false);
-        self::assertCount(4, $links);
+        self::assertGreaterThan(3, count($links));
 
         /** @psalm-suppress PossiblyUndefinedArrayOffset */
         [$web, $media, $doc, $bare] = $links;

--- a/test/fixture/links.json
+++ b/test/fixture/links.json
@@ -84,6 +84,52 @@
                 "link_type": "Web",
                 "key": "link-without-text",
                 "url": "https://www.example.com"
+            },
+            {
+                "link_type": "Any",
+                "key": "link-that-doesnt-link-anywhere-for-any-type",
+                "text": "Some Text"
+            },
+            {
+                "link_type": "Web",
+                "key": "web-link-with-no-link",
+                "text": "Some Text"
+            },
+            {
+                "link_type": "Document",
+                "key": "document-link-with-no-link",
+                "text": "Some Text"
+            },
+            {
+                "link_type": "Media",
+                "key": "media-link-with-no-link",
+                "text": "Some Text"
+            },
+            {
+                "link_type": "Media",
+                "kind": "image",
+                "key": "image-link-with-no-link",
+                "text": "Some Text"
+            },
+            {
+                "link_type": "Any",
+                "key": "A link with no text, type or url",
+                "variant": "Primary"
+            },
+            {
+                "link_type": "Web",
+                "key": "A web link with no text or url",
+                "variant": "Primary"
+            },
+            {
+                "link_type": "Document",
+                "key": "A document link with no text or id/uid",
+                "variant": "Primary"
+            },
+            {
+                "link_type": "Media",
+                "key": "A media link with no text or url",
+                "variant": "Primary"
             }
         ],
         "variants": [


### PR DESCRIPTION
In the UI, it is possible for the new text link field to yield what looks like a link structure without any linking information, i.e. a media or web link without a url property, or a document link without an id/uid etc.

This patch updates the factory to test for these 'broken' links and either return empty fragments or string fragments