### PR TITLE
Cover new cases for preview expiry

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@
 /test/ export-ignore
 /Makefile export-ignore
 /renovate.json export-ignore
+*.http  text eol=crlf

--- a/src/Exception/PreviewTokenExpired.php
+++ b/src/Exception/PreviewTokenExpired.php
@@ -15,7 +15,7 @@ use function explode;
 use function is_string;
 use function property_exists;
 use function sprintf;
-use function strpos;
+use function str_contains;
 
 final class PreviewTokenExpired extends RequestFailure
 {
@@ -28,11 +28,16 @@ final class PreviewTokenExpired extends RequestFailure
     public static function isPreviewTokenExpiry(ResponseInterface $response): bool
     {
         $type = $response->getHeaderLine('content-type');
-        if (strpos($type, 'json') === false) {
+        if (! str_contains($type, 'json')) {
             return false;
         }
 
-        $payload = Json::decodeObject((string) $response->getBody());
+        try {
+            $payload = Json::decodeObject((string) $response->getBody());
+        } catch (JsonError) {
+            return false;
+        }
+
         $error = self::extractErrorMessage($payload);
 
         if ($error === null) {
@@ -75,6 +80,11 @@ final class PreviewTokenExpired extends RequestFailure
 
     private static function errorStringHasMagicWords(string $error): bool
     {
+        // We seem to get 404 errors these days when a preview is no longer accessible…
+        if (str_contains($error, 'websitePreviewId=') && str_contains($error, 'not found')) {
+            return true;
+        }
+
         $words = array_map('strtolower', explode(' ', $error));
 
         return count(array_intersect($words, self::MAGIC_WORDS)) === count(self::MAGIC_WORDS);

--- a/test/Unit/Exception/PreviewTokenExpiredTest.php
+++ b/test/Unit/Exception/PreviewTokenExpiredTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace PrismicTest\Exception;
 
+use Laminas\Diactoros\Response;
 use Laminas\Diactoros\Response\JsonResponse;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Prismic\Exception\PreviewTokenExpired;
 use PrismicTest\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
+
+use function file_get_contents;
 
 final class PreviewTokenExpiredTest extends TestCase
 {
@@ -26,6 +29,13 @@ final class PreviewTokenExpiredTest extends TestCase
                     'message' => 'This preview token has expired',
                     'oauth_initiate' => 'https://something.prismic.io/auth',
                     'oauth_token' => 'https://something.prismic.io/auth/token',
+                ],
+                404,
+            ],
+            'Yet another change to the error format around 2024 maybe' => [
+                [
+                    'type' => 'api_notfound_error',
+                    'message' => 'https://whatever.prismic.io/previews/aID57hcAACYAP-nz:aIIBzxcAACYAQYax?websitePreviewId=Z-aJqxEAACgA_GAh not found',
                 ],
                 404,
             ],
@@ -72,5 +82,14 @@ final class PreviewTokenExpiredTest extends TestCase
     {
         $response = new JsonResponse($bodyPayload, $responseCode);
         self::assertTrue(PreviewTokenExpired::isPreviewTokenExpiry($response));
+    }
+
+    public function testPrismicFuckedUp422ResponseIsNotAPreviewExpiryException(): void
+    {
+        $message = file_get_contents(__DIR__ . '/../../fixture/responses/422.http');
+        self::assertIsString($message);
+        $response = Response\Serializer::fromString($message);
+
+        self::assertFalse(PreviewTokenExpired::isPreviewTokenExpiry($response));
     }
 }

--- a/test/fixture/responses/422.http
+++ b/test/fixture/responses/422.http
@@ -1,0 +1,19 @@
+HTTP/1.1 422 Unknown
+Content-Type: application/json
+Content-Length: 103
+Connection: close
+Date: Thu, 24 Jul 2025 11:14:42 GMT
+X-Amzn-Trace-Id: Root=1-6832159f-102bd7a711dda3ff47d6ef4e
+X-RateLimit-Limit: 200
+X-RateLimit-Remaining: 199
+X-RateLimit-Reset: 1753355680
+x-amzn-RequestId: 5dd39803-8818-448f-9758-d109ddec3470
+x-amz-apigw-id: ONhRDHzqIAMFTAw=
+X-Cache: Error from cloudfront
+Via: 1.1 ed63ba28ec03a429dffd93eedad2fd5e.cloudfront.net (CloudFront)
+X-Amz-Cf-Pop: LHR50-P5
+X-Amz-Cf-Id: QwhPEL2YBf5C2J2Thjmfyz5XGLeoYGFXKc4SReKZjAJaMG15KCWWZg==
+
+
+The maximum size of response body is: 6 MO (6291456 bytes)
+Your response is:  6.03 MO (6320955 bytes)


### PR DESCRIPTION
At some point Prismic wisely decided to change how expired previews are reported without telling anyone.

They're too good to use an RFC or something and adopt Problem Details, so we'll do the best thing and scan strings for more magic values. Yay!

Also, adds a fixture for the newly discovered and un-documented special error situation where they refuse to send you the response if it is too large.

Helpfully, this 422 error, is sent with an `application/json` content type header and a plain text body.

If anyone from Prismic is reading this, fuck you.