### PR TITLE
Introduce `ResponseTooLarge` exception type

### DIFF
--- a/src/Exception/RequestFailure.php
+++ b/src/Exception/RequestFailure.php
@@ -49,6 +49,10 @@ class RequestFailure extends RuntimeException implements PrismicError
             return PreviewTokenExpired::with($request, $response);
         }
 
+        if (ResponseTooLarge::matches($response)) {
+            return ResponseTooLarge::with($request, $response);
+        }
+
         $error = new self(sprintf(
             'Error %d. The request to the URL "%s" was rejected by the api. The error response body was "%s"',
             $status,

--- a/src/Exception/ResponseTooLarge.php
+++ b/src/Exception/ResponseTooLarge.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prismic\Exception;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+use function sprintf;
+use function str_contains;
+
+final class ResponseTooLarge extends RequestFailure
+{
+    public static function matches(ResponseInterface $response): bool
+    {
+        if ($response->getStatusCode() !== 422) {
+            return false;
+        }
+
+        return str_contains(
+            (string) $response->getBody(),
+            'maximum size of response body',
+        );
+    }
+
+    public static function with(RequestInterface $request, ResponseInterface $response): self
+    {
+        $error = new self(
+            sprintf(
+                'Your request was rejected because the response would be too large. Error message: %s',
+                (string) $response->getBody(),
+            ),
+            $response->getStatusCode(),
+        );
+        $error->response = $response;
+        $error->request = $request;
+
+        return $error;
+    }
+}

--- a/test/Unit/Exception/RequestFailureTest.php
+++ b/test/Unit/Exception/RequestFailureTest.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace PrismicTest\Exception;
 
 use Laminas\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\Response\Serializer;
 use Prismic\Exception\PreviewTokenExpired;
 use Prismic\Exception\RequestFailure;
+use Prismic\Exception\ResponseTooLarge;
 use PrismicTest\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
+
+use function file_get_contents;
 
 final class RequestFailureTest extends TestCase
 {
@@ -19,5 +23,22 @@ final class RequestFailureTest extends TestCase
 
         $error = RequestFailure::withClientError($request, $response);
         $this->assertInstanceOf(PreviewTokenExpired::class, $error);
+    }
+
+    public function testExpectedResponseTooLargeError(): void
+    {
+        $message = file_get_contents(__DIR__ . '/../../fixture/responses/422.http');
+        self::assertIsString($message);
+        $response = Serializer::fromString($message);
+        $request = $this->createMock(RequestInterface::class);
+
+        $error = RequestFailure::withClientError($request, $response);
+        self::assertInstanceOf(ResponseTooLarge::class, $error);
+
+        self::assertSame($request, $error->getRequest());
+        self::assertSame($response, $error->getResponse());
+
+        self::assertStringContainsString('Your request was rejected because the response would be too large', $error->getMessage());
+        self::assertStringContainsString('Your response is:  6.03 MO', $error->getMessage());
     }
 }


### PR DESCRIPTION
Closes #617